### PR TITLE
improve manifest

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Plant-it",
+  "name": "Plant-it, self-hosted gardening companion app",
   "icons": [
     {
       "src": "favicon.ico",
@@ -8,12 +8,12 @@
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
+      "src": "android-chrome-192x192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "logo512.png",
+      "src": "android-chrome-512x512.png",
       "type": "image/png",
       "sizes": "512x512"
     }


### PR DESCRIPTION
When you try to "install" the web app, it shows the default React values:
Before:
![default_react](https://github.com/MDeLuise/plant-it/assets/29866109/de549e43-05b4-4177-a58d-15ae8a890bbf)
After:
![after](https://github.com/MDeLuise/plant-it/assets/29866109/7e3a5c9c-92bc-433a-b8e3-db3147f5d69c)


I changed the name and the icons, but I don't know which colors will look good.
