### PR TITLE
Add configurable CORS origin through environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,24 +121,31 @@ There are 2 configuration file available:
   MYSQL_PORT=3306
   MYSQL_USERNAME=root
   MYSQL_PSW=root
-  JWT_SECRET=putTheSecretHere
-  JWT_EXP=1
   MYSQL_ROOT_PASSWORD=root
   MYSQL_DATABASE=bootdb
+  
+  JWT_SECRET=putTheSecretHere
+  JWT_EXP=1
+  
   USERS_LIMIT=-1 # including the admin account, so <= 0 if undefined, >= 2 if defined
+  UPLOAD_DIR= # path to the directory used to store uploaded images, if on docker deployment leave as it is and change the volume binding if needed
+  
   CACHE_TTL=86400
   CACHE_HOST=cache
   CACHE_PORT=6379
+  
   TRAFLE_KEY= # put you key here, otherwise the "search" feature will include only user generated species
-  UPLOAD_DIR= # path to the directory used to store uploaded images, if on docker deployment leave as it is and change the volume binding if needed
+  FRONTEND_URL=http://localhost:3000 # CORS allowed origin
   ```
   Change the properties values according to your system.
 
 * `deployment/frontend.env`: file containing the configuration for the frontend. An example of content is the following:
   ```
   API_URL=http://localhost:8080/api
-  BROWSER=none
+  
   PAGE_SIZE=25
+  
+  BROWSER=none
   ```
   Change the properties values according to your system.
 
@@ -149,7 +156,7 @@ Feel free to contribute and help improve the repo.
 You can submit any of this in the [issues](https://github.com/MDeLuise/plant-it/issues/new/choose) section of the repository. Chose the right template and then fill the required info.
 
 ### Bug fix
-If you fix a bug, please follow the [contribution-guideline](https://github.com/MDeLuise/plant-it#how-to-contribute) in order to merge the fix in the repository.
+If you fix a bug, please follow the [contribution guideline](https://github.com/MDeLuise/plant-it#how-to-contribute) in order to merge the fix in the repository.
 
 ### Feature development
 Let's discuss first possible solutions for the development before start working on that, please open a [feature request issue](https://github.com/MDeLuise/plant-it/issues/new?assignees=&labels=&projects=&template=fr.yml).
@@ -169,6 +176,6 @@ To fix a bug or create a feature, follow these steps:
 #### Local environment
 If you want to make some changes in the project, you can use the following commands:
 * in order to run the frontend: `cd frontend`, then `npm run dev`.
-* in order to run the backend: `cd backend`, then `./mvnw spring-boot:run -Dspring-boot.run.profiles=dev`. This enables the `dev` profile, which uses an embedded h2 database instead of one external mysql instance, and creates a user with username `user` and password `user` with a predefined plant's collection.
+* in order to run the backend: `cd backend`, then `./mvnw spring-boot:run -Dspring-boot.run.profiles=dev -DcopyFiles`. This enables the `dev` profile, which uses an embedded h2 database instead of one external mysql instance, and creates a user with username `user` and password `user` with a predefined plant's collection. Also a dummy user uploaded image is copied under `/tmp/plant-it/` directory.
 
 Consider that this environment speed up the developing process, but the app should be tested (at least for new big features) even without the `dev` backend profile and with a local docker deployment.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>plant-it</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <name>Plant it</name>
-    <description>Gardening companion system</description>
+    <description>Gardening companion app</description>
     <properties>
         <java.version>20</java.version>
         <start-class>com.github.mdeluise.plantit.Application</start-class>
@@ -158,7 +158,7 @@
                         <version>1.8</version>
                         <executions>
                             <execution>
-                                <phase>test</phase>
+                                <phase>initialize</phase>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>

--- a/backend/src/main/java/com/github/mdeluise/plantit/ApplicationConfig.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/ApplicationConfig.java
@@ -28,11 +28,12 @@ import redis.embedded.RedisServer;
 @OpenAPIDefinition(
     info = @Info(
         title = "Plant-it REST API", version = "1.0",
-        description = "<h1>Introduction</h1>" + "<p>Plant-it is a self-hosted, open " + "source, ...</p>",
-        license = @License(name = "Apache 2.0", url = "https://www.apache.org/licenses/LICENSE-2.0"),
+        description = "<h1>Introduction</h1>" + "<p>Plant-it is a self-hosted, open " +
+                          "source, gardening companion app.</p>",
+        license = @License(name = "GPL 3.0", url = "https://www.gnu.org/licenses/gpl-3.0.en.html"),
         contact = @Contact(name = "GitHub page", url = "https://github.com/MDeLuise/plant-it")
     ), security = {@SecurityRequirement(name = "bearerAuth")}, servers = {
-    @Server(description = "Production", url = "/api"),
+    @Server(description = "Localhost", url = "/api"),
     @Server(
         description = "Custom",
         url = "{protocol}://{host}:{port}/{basePath}",

--- a/backend/src/main/java/com/github/mdeluise/plantit/security/ApplicationSecurityConfig.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/security/ApplicationSecurityConfig.java
@@ -3,6 +3,7 @@ package com.github.mdeluise.plantit.security;
 import com.github.mdeluise.plantit.security.apikey.ApiKeyFilter;
 import com.github.mdeluise.plantit.security.jwt.JwtTokenFilter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -103,12 +104,12 @@ public class ApplicationSecurityConfig {
 
     @Bean
     @Profile("dev")
-    public WebMvcConfigurer corsConfigurer() {
+    public WebMvcConfigurer corsConfigurer(@Value("${server.cors.allowed-origins}") String allowedOrigins) {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:3000")
+                        .allowedOrigins(allowedOrigins)
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTION");
             }
         };

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -65,6 +65,7 @@ jwt.cookie.name                                 = plant-it
 #
 server.port                                     = 8085
 server.servlet.context-path                     = /api
+server.cors.allowed-origins                     = ${FRONTEND_URL:http://localhost:3000}
 
 
 #

--- a/backend/src/main/resources/application-integration.properties
+++ b/backend/src/main/resources/application-integration.properties
@@ -52,6 +52,7 @@ jwt.cookie.name                                 = plant-it
 #
 server.port                                     = 8090
 server.address                                  = 0.0.0.0
+server.cors.allowed-origins                     = ${FRONTEND_URL:http://localhost:3000}
 
 
 #

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -46,6 +46,7 @@ jwt.cookie.name                            = plant-it
 #
 server.port                                = 8080
 server.servlet.context-path                = /api
+server.cors.allowed-origins                = ${FRONTEND_URL:http://localhost:3000}
 
 
 #

--- a/deployment/backend.env
+++ b/deployment/backend.env
@@ -2,11 +2,17 @@ MYSQL_HOST=db
 MYSQL_PORT=3306
 MYSQL_USERNAME=root
 MYSQL_PSW=root
-JWT_SECRET=putTheSecretHere
-JWT_EXP=1
 MYSQL_ROOT_PASSWORD=root
 MYSQL_DATABASE=bootdb
+
+JWT_SECRET=putTheSecretHere
+JWT_EXP=1
+
 USERS_LIMIT=2 # including the admin account, so <= 0 if undefined, >= 2 if defined
+
 CACHE_TTL=86400
 CACHE_HOST=cache
 CACHE_PORT=6379
+
+FRONTEND_URL=http://localhost:3000
+

--- a/deployment/frontend.env
+++ b/deployment/frontend.env
@@ -1,3 +1,6 @@
 API_URL=http://localhost:8080/api
-BROWSER=none
+
 PAGE_SIZE=25
+
+BROWSER=none
+


### PR DESCRIPTION
This PR fixes issue #10, i.e. adds an environment variable `BASE_URL` used to set the CORS origin.

Other changes in this pull request:
- fix copyFiles property phase, now the run goal in `dev` profile also copy needed dummy file
- fix app description in Swagger UI


