### PR TITLE
Fix trefle extractor always added to the extractors chain

### DIFF
--- a/backend/src/main/java/com/github/mdeluise/plantit/plantinfo/PlantInfoExtractorFactory.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plantinfo/PlantInfoExtractorFactory.java
@@ -16,7 +16,7 @@ public class PlantInfoExtractorFactory {
                                      TreflePlantInfoExtractor treflePlantInfoExtractor,
                                      LocalPlantInfoExtractor localPlantInfoExtractor) {
         this.localPlantInfoExtractor = localPlantInfoExtractor;
-        if (trefleKey != null) {
+        if (trefleKey != null && !trefleKey.isBlank()) {
             localPlantInfoExtractor.setNext(treflePlantInfoExtractor);
         }
     }


### PR DESCRIPTION
This PR fixes issue #15, i.e. the trefle extractor is always added to the extractors chain, this leads to error since the system tries to send request to trefle system without a key.,


