### PR TITLE
Add backend error messages in the UI

### DIFF
--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantController.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantController.java
@@ -66,4 +66,10 @@ public class PlantController {
     public ResponseEntity<Long> countDistinctBotanicalInfo() {
         return ResponseEntity.ok(plantService.getNumberOfDistinctBotanicalInfo());
     }
+
+
+    @GetMapping("/{plantName}/_name-exists")
+    public ResponseEntity<Boolean> isNameAlreadyExisting(@PathVariable String plantName) {
+        return ResponseEntity.ok(plantService.isNameAlreadyExisting(plantName));
+    }
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantRepository.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantRepository.java
@@ -11,4 +11,6 @@ public interface PlantRepository extends JpaRepository<Plant, Long> {
     Page<Plant> findAllByOwnerAndState(User user, PlantState plantState, Pageable pageable);
 
     Long countByOwner(User user);
+
+    boolean existsByOwnerAndPersonalName(User user, String personalName);
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantService.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantService.java
@@ -93,4 +93,9 @@ public class PlantService {
                                          .map(entity -> entity.getBotanicalInfo().getId())
                                          .collect(Collectors.toSet()).size();
     }
+
+
+    public boolean isNameAlreadyExisting(String plantName) {
+        return plantRepository.existsByOwnerAndPersonalName(authenticatedUserService.getAuthenticatedUser(), plantName);
+    }
 }

--- a/frontend/src/components/EditEvent.tsx
+++ b/frontend/src/components/EditEvent.tsx
@@ -14,7 +14,7 @@ import {
     TextField,
     alpha,
 } from "@mui/material";
-import { AxiosInstance } from "axios";
+import { AxiosError, AxiosInstance } from "axios";
 import React, { useEffect, useState } from "react";
 import { diaryEntry, plant } from "../interfaces";
 import { titleCase } from "../common";
@@ -26,6 +26,7 @@ import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import SaveOutlinedIcon from '@mui/icons-material/SaveOutlined';
 import ClearOutlinedIcon from '@mui/icons-material/ClearOutlined';
+import ErrorDialog from "./ErrorDialog";
 
 
 function ConfirmDialog(props: {
@@ -81,6 +82,8 @@ export default function EditEvent(props: {
     const [confirmDialogTitle, setConfirmDialogTitle] = useState<string>("");
     const [confirmDialogText, setConfirmDialogText] = useState<string>("");
     const [confirmDialogCallback, setConfirmDialogCallback] = useState<() => void>(() => () => { });
+    const [errorDialogShown, setErrorDialogShown] = useState<boolean>(false);
+    const [errorDialogText, setErrorDialogText] = useState<string>();
 
     const updateEvent = (): void => {
         let newTarget: plant = props.plants.filter((en) => en.personalName === selectedPlantName)[0];
@@ -95,6 +98,9 @@ export default function EditEvent(props: {
                 props.updateLog(res.data);
                 props.setOpen(false);
                 setEdit(false);
+            })
+            .catch((err) => {
+                showErrorDialog(err);
             });
     };
 
@@ -105,7 +111,16 @@ export default function EditEvent(props: {
                 props.setOpen(false);
                 setEdit(false);
                 setConfirmDialogOpen(false);
+            })
+            .catch((err) => {
+                showErrorDialog(err);
             });
+    };
+
+
+    const showErrorDialog = (res: AxiosError) => {
+        setErrorDialogText((res.response?.data as any).message);
+        setErrorDialogShown(true);
     };
 
     useEffect(() => {
@@ -119,6 +134,12 @@ export default function EditEvent(props: {
 
     return (
         <>
+            <ErrorDialog
+                text={errorDialogText}
+                open={errorDialogShown}
+                close={() => setErrorDialogShown(false)}
+            />
+
             <ConfirmDialog
                 open={confirmDialogOpen}
                 close={() => setConfirmDialogOpen(false)}

--- a/frontend/src/components/ErrorDialog.tsx
+++ b/frontend/src/components/ErrorDialog.tsx
@@ -1,0 +1,55 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography, styled } from "@mui/material";
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
+
+const BootstrapDialog = styled(Dialog)(({ theme }) => ({
+    '& .MuiDialogContent-root': {
+        padding: theme.spacing(2),
+    },
+    '& .MuiDialogActions-root': {
+        padding: theme.spacing(1),
+    },
+}));
+
+export default function ErrorDialog(props: {
+    text?: string,
+    open: boolean,
+    close: () => void;
+}) {
+    return <div>
+        <BootstrapDialog
+            onClose={() => props.close()}
+            open={props.open}
+        >
+            <DialogTitle sx={{ m: 0, p: 2 }} >
+                Error
+            </DialogTitle>
+            <IconButton
+                aria-label="close"
+                onClick={() => props.close()}
+                sx={{
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: (theme) => theme.palette.grey[500],
+                }}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent dividers>
+                <Typography gutterBottom>
+                    {props.text}
+                </Typography>
+            </DialogContent>
+            <DialogActions>
+                <Button
+                    autoFocus
+                    onClick={() => props.close()}
+                    fullWidth
+                >
+                    Ok
+                </Button>
+            </DialogActions>
+        </BootstrapDialog>
+    </div>;
+}


### PR DESCRIPTION
This PR fixes issue #14, i.e. adds backend error message in the UI.
Example of rendered errors:
<p float="middle">
<img src="https://github.com/MDeLuise/plant-it/assets/66636702/7a600f37-a720-46b7-a2d5-2966c6800123" width="24%" />
<img src="https://github.com/MDeLuise/plant-it/assets/66636702/d6bf874f-4a5e-4855-8297-be4edaca5f7b"
om/MDeLuise/plan" width="24%"  />
<img src="https://github.com/MDeLuise/plant-it/assets/66636702/2703ea52-3164-4251-9349-5e2db9856709" width="24%"  />
<img src="https://github.com/MDeLuise/plant-it/assets/66636702/ef2bf11b-559a-4b3d-a1c6-589947814d52" width="24%"  />
</p>

