### PR TITLE
Add lazy load for plant images

### DIFF
--- a/backend/src/main/java/com/github/mdeluise/plantit/image/ImageController.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/image/ImageController.java
@@ -1,5 +1,8 @@
 package com.github.mdeluise.plantit.image;
 
+import java.util.Base64;
+import java.util.Collection;
+
 import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfo;
 import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfoService;
 import com.github.mdeluise.plantit.image.storage.ImageStorageService;
@@ -18,9 +21,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.Base64;
-import java.util.Collection;
 
 @RestController
 @RequestMapping("/image")

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance } from "axios";
+import axios, { AxiosError, AxiosInstance } from "axios";
 
 export const isBigScreen = (): boolean => {
     return window.screen.width > 768;
@@ -13,7 +13,8 @@ const readImage = (requestor: AxiosInstance, imageUrl: string): Promise<string> 
         requestor.get(`image/content${imageUrl}`)
             .then((res) => {
                 resolve(`data:application/octet-stream;base64,${res.data}`);
-            });
+            })
+            .catch((err) => reject(err));
     });
 };
 
@@ -37,4 +38,15 @@ export const isBackendReachable = (requestor: AxiosInstance): Promise<boolean> =
             .then((_res) => resolve(true))
             .catch((_err) => resolve(false));
     });
+};
+
+export const getErrMessage = (err: any): string => {
+    console.error(err);
+    if (err.response != undefined) {
+        return err.response.data.message;
+    }
+    if (axios.isAxiosError(err)) {
+        return (err as AxiosError).message;
+    }
+    return "Some error occurred";
 };

--- a/frontend/src/components/AllLogs.tsx
+++ b/frontend/src/components/AllLogs.tsx
@@ -160,6 +160,7 @@ export default function AllLogs(props: {
     entries: diaryEntry[],
     plants: plant[],
     openEditEvent: (arg: diaryEntry) => void,
+    printError: (err: any) => void;
 }) {
     const pageSize = 5;
     const [entities, setEntities] = useState<diaryEntry[]>([]);
@@ -230,6 +231,9 @@ export default function AllLogs(props: {
                 } else {
                     setCircularProgressVisible(false);
                 }
+            })
+            .catch((err) => {
+                props.printError(err);
             });
     };
 

--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import axios, { AxiosError, AxiosInstance } from 'axios';
+import { AxiosError, AxiosInstance } from 'axios';
 import { NavigateFunction, useNavigate } from "react-router";
 import secureLocalStorage from "react-secure-storage";
 import Avatar from '@mui/material/Avatar';
@@ -20,7 +20,7 @@ import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import FormControl from '@mui/material/FormControl';
 import { FormHelperText } from "@mui/material";
 import ErrorDialog from "./ErrorDialog";
-import { isBackendReachable } from "../common";
+import { getErrMessage, isBackendReachable } from "../common";
 
 export default function (props: { requestor: AxiosInstance; }) {
     const navigate: NavigateFunction = useNavigate();
@@ -45,8 +45,8 @@ export default function (props: { requestor: AxiosInstance; }) {
                 getOrCreateApiKey(jwt);
                 secureLocalStorage.setItem("plant-it-username", username);
             })
-            .catch((err: AxiosError) => {
-                setErrorDialogText((err.response?.data as any).message);
+            .catch((err) => {
+                setErrorDialogText(getErrMessage(err));
                 setErrorDialogShown(true);
             });
     };
@@ -73,7 +73,7 @@ export default function (props: { requestor: AxiosInstance; }) {
                         navigate('/');
                     })
                     .catch((err) => {
-                        setErrorDialogText((err.response?.data as any).message);
+                        setErrorDialogText(getErrMessage(err));
                         setErrorDialogShown(true);
                     });
             });
@@ -85,11 +85,11 @@ export default function (props: { requestor: AxiosInstance; }) {
             username: username,
             password: password
         })
-            .then((_response) => {
+            .then((_res) => {
                 doLogin(event);
             })
-            .catch((err: AxiosError) => {
-                setErrorDialogText((err.response?.data as any).message);
+            .catch((err) => {
+                setErrorDialogText(getErrMessage(err));
                 setErrorDialogShown(true);
             });
     };

--- a/frontend/src/components/EditEvent.tsx
+++ b/frontend/src/components/EditEvent.tsx
@@ -70,7 +70,8 @@ export default function EditEvent(props: {
     toEdit?: diaryEntry,
     open: boolean,
     setOpen: (arg: boolean) => void,
-    removeFromLog: (arg: number) => void;
+    removeFromLog: (arg: number) => void,
+    printError: (err: any) => void;
 }) {
     const [date, setDate] = useState<Dayjs>(dayjs());
     const [selectedPlantName, setSelectedPlantName] = useState<string>();
@@ -82,8 +83,6 @@ export default function EditEvent(props: {
     const [confirmDialogTitle, setConfirmDialogTitle] = useState<string>("");
     const [confirmDialogText, setConfirmDialogText] = useState<string>("");
     const [confirmDialogCallback, setConfirmDialogCallback] = useState<() => void>(() => () => { });
-    const [errorDialogShown, setErrorDialogShown] = useState<boolean>(false);
-    const [errorDialogText, setErrorDialogText] = useState<string>();
 
     const updateEvent = (): void => {
         let newTarget: plant = props.plants.filter((en) => en.personalName === selectedPlantName)[0];
@@ -100,7 +99,7 @@ export default function EditEvent(props: {
                 setEdit(false);
             })
             .catch((err) => {
-                showErrorDialog(err);
+                props.printError(err);
             });
     };
 
@@ -113,15 +112,10 @@ export default function EditEvent(props: {
                 setConfirmDialogOpen(false);
             })
             .catch((err) => {
-                showErrorDialog(err);
+                props.printError(err);
             });
     };
 
-
-    const showErrorDialog = (res: AxiosError) => {
-        setErrorDialogText((res.response?.data as any).message);
-        setErrorDialogShown(true);
-    };
 
     useEffect(() => {
         setSelectedPlantName(props.toEdit?.diaryTargetPersonalName);
@@ -134,12 +128,6 @@ export default function EditEvent(props: {
 
     return (
         <>
-            <ErrorDialog
-                text={errorDialogText}
-                open={errorDialogShown}
-                close={() => setErrorDialogShown(false)}
-            />
-
             <ConfirmDialog
                 open={confirmDialogOpen}
                 close={() => setConfirmDialogOpen(false)}

--- a/frontend/src/components/ErrorDialog.tsx
+++ b/frontend/src/components/ErrorDialog.tsx
@@ -18,7 +18,7 @@ export default function ErrorDialog(props: {
 }) {
     return <div>
         <BootstrapDialog
-            onClose={() => props.close()}
+            onClose={props.close}
             open={props.open}
         >
             <DialogTitle sx={{ m: 0, p: 2 }} >
@@ -26,7 +26,7 @@ export default function ErrorDialog(props: {
             </DialogTitle>
             <IconButton
                 aria-label="close"
-                onClick={() => props.close()}
+                onClick={props.close}
                 sx={{
                     position: 'absolute',
                     right: 8,
@@ -36,7 +36,9 @@ export default function ErrorDialog(props: {
             >
                 <CloseIcon />
             </IconButton>
-            <DialogContent dividers>
+            <DialogContent dividers sx={{
+                overflowWrap: "break-word",
+            }}>
                 <Typography gutterBottom>
                     {props.text}
                 </Typography>
@@ -44,7 +46,7 @@ export default function ErrorDialog(props: {
             <DialogActions>
                 <Button
                     autoFocus
-                    onClick={() => props.close()}
+                    onClick={props.close}
                     fullWidth
                 >
                     Ok

--- a/frontend/src/components/PlantDetails.tsx
+++ b/frontend/src/components/PlantDetails.tsx
@@ -32,7 +32,7 @@ function PlantImage(props: {
     key: string,
     active: boolean,
     requestor: AxiosInstance,
-    showErrorDialog: (text: AxiosError) => void;
+    printError: (err: any) => void;
 }) {
     const [loaded, setLoaded] = useState<boolean>(false);
     const [imgBase64, setImgBase64] = useState<string>();
@@ -43,7 +43,7 @@ function PlantImage(props: {
                 setImgBase64(res.data);
             })
             .catch((err) => {
-                props.showErrorDialog(err);
+                props.printError(err);
             });
     }, [props.imgId]);
 
@@ -54,7 +54,11 @@ function PlantImage(props: {
                 <Skeleton
                     variant="rounded"
                     animation="wave"
-                    sx={{ width: "100%", height: "100%", zIndex: 1 }}
+                    sx={{
+                        width: "100%",
+                        height: "100%",
+                        zIndex: 1
+                    }}
                 />
             }
             {
@@ -79,7 +83,7 @@ function Bottombar(props: {
     visible: boolean,
     entity?: plant,
     addImageBase64: (arg: string) => void,
-    showErrorDialog: (text: AxiosError) => void;
+    printError: (err: any) => void;
 }) {
     const addEntityImage = (toUpload: File): void => {
         let formData = new FormData();
@@ -91,7 +95,7 @@ function Bottombar(props: {
                 });
             })
             .catch((err) => {
-                props.showErrorDialog(err);
+                props.printError(err);
             });
     };
 
@@ -184,7 +188,7 @@ function ReadMoreReadLess(props: {
 function PlantHeader(props: {
     requestor: AxiosInstance,
     entity?: plant,
-    showErrorDialog: (text: AxiosError) => void;
+    printError: (err: any) => void;
 }) {
     const [imageLoaded, setImageLoaded] = useState<boolean>(false);
     const [checkedImages, setCheckedImages] = useState<boolean>(false);
@@ -202,12 +206,15 @@ function PlantHeader(props: {
                             setCheckedImages(true);
                         })
                         .catch((err) => {
-                            props.showErrorDialog(err);
+                            props.printError(err);
                         });
                     return;
                 }
                 setImageIds(res.data.reverse());
                 setCheckedImages(true);
+            })
+            .catch((err) => {
+                props.printError(err);
             });
     }, [props.entity]);
 
@@ -254,7 +261,7 @@ function PlantHeader(props: {
                                     key={index.toString()}
                                     active={index === activeIndex}
                                     requestor={props.requestor}
-                                    showErrorDialog={props.showErrorDialog}
+                                    printError={props.printError}
                                 />
                             </SwiperSlide>;
                         })
@@ -330,16 +337,10 @@ export default function PlantDetails(props: {
     open: boolean,
     close: () => void;
     entity?: plant,
-    requestor: AxiosInstance;
+    requestor: AxiosInstance,
+    printError: (err: any) => void;
 }) {
     const [selectedTab, setSelectedTab] = useState<number>(0);
-    const [errorDialogShown, setErrorDialogShown] = useState<boolean>(false);
-    const [errorDialogText, setErrorDialogText] = useState<string>();
-
-    const showErrorDialog = (res: AxiosError) => {
-        setErrorDialogText((res.response?.data as any).message);
-        setErrorDialogShown(true);
-    };
 
     return (
         <Drawer
@@ -347,12 +348,6 @@ export default function PlantDetails(props: {
             open={props.open}
             onClose={props.close}
         >
-
-            <ErrorDialog
-                text={errorDialogText}
-                open={errorDialogShown}
-                close={() => setErrorDialogShown(false)}
-            />
 
             <Box
                 sx={{
@@ -376,7 +371,7 @@ export default function PlantDetails(props: {
                 <PlantHeader
                     requestor={props.requestor}
                     entity={props.entity}
-                    showErrorDialog={showErrorDialog}
+                    printError={props.printError}
                 />
 
                 <Box sx={{
@@ -426,7 +421,7 @@ export default function PlantDetails(props: {
                     entity={props.entity}
                     addImageBase64={(arg: string) => {
                     }}
-                    showErrorDialog={showErrorDialog}
+                    printError={props.printError}
                 />
             </Box>
         </Drawer>

--- a/frontend/src/components/SearchPage.tsx
+++ b/frontend/src/components/SearchPage.tsx
@@ -14,7 +14,8 @@ function BotanicalEntity(props: {
     entity: botanicalInfo,
     requestor: AxiosInstance,
     addClick: (arg: botanicalInfo) => void,
-    addEntity: (arg: plant) => void;
+    addEntity: (arg: plant) => void,
+    printError: (err: any) => void;
 }) {
     const [imageLoaded, setImageLoaded] = useState<boolean>(false);
     const [imgSrc, setImgSrc] = useState<string>();
@@ -24,6 +25,9 @@ function BotanicalEntity(props: {
             .then((res) => {
                 setImageLoaded(true);
                 setImgSrc(res);
+            })
+            .catch((err) => {
+                props.printError(err);
             });
     };
 
@@ -47,7 +51,11 @@ function BotanicalEntity(props: {
         >
             {
                 !imageLoaded &&
-                <Skeleton variant="rounded" animation="wave" sx={{ width: "100%", height: "100%" }} />
+                <Skeleton
+                    variant="rounded"
+                    animation="wave"
+                    sx={{ width: "100%", height: "100%" }}
+                />
             }
 
             <Chip
@@ -151,7 +159,8 @@ function AddNewBotanicalInfo(props: {
 
 export default function SearchPage(props: {
     requestor: AxiosInstance,
-    plants: plant[];
+    plants: plant[],
+    printError: (err: any) => void;
 }) {
     const [scientificName, setScientificName] = useState<string>("");
     const [botanicalInfos, setBotanicalInfos] = useState<botanicalInfo[]>([]);
@@ -175,6 +184,9 @@ export default function SearchPage(props: {
                 });
                 setBotanicalInfos(newBotanicalInfos);
             }))
+            .catch((err) => {
+                props.printError(err);
+            })
             .finally(() => setLoading(false));
     };
 
@@ -191,6 +203,7 @@ export default function SearchPage(props: {
                 entity={selectedBotanicalInfo}
                 plants={props.plants}
                 name={scientificName}
+                printError={props.printError}
             />
 
             <OutlinedInput
@@ -225,8 +238,16 @@ export default function SearchPage(props: {
                 {
                     loading &&
                     <>
-                        <Skeleton variant="rounded" animation="wave" sx={{ width: isBigScreen() ? "30vw" : "100%", height: "180px" }} />
-                        <Skeleton variant="rounded" animation="wave" sx={{ width: isBigScreen() ? "30vw" : "100%", height: "180px" }} />
+                        <Skeleton
+                            variant="rounded"
+                            animation="wave"
+                            sx={{ width: isBigScreen() ? "30vw" : "100%", height: "180px" }}
+                        />
+                        <Skeleton
+                            variant="rounded"
+                            animation="wave"
+                            sx={{ width: isBigScreen() ? "30vw" : "100%", height: "180px" }}
+                        />
                     </>
                 }
                 {botanicalInfos.map(botanicalInfo => {
@@ -238,9 +259,11 @@ export default function SearchPage(props: {
                             setAddPlantOpen(true);
                         }}
                         addEntity={(en: plant) => props.plants.push(en)}
+                        key={botanicalInfo.id}
+                        printError={props.printError}
                     />;
                 })}
-                < AddNewBotanicalInfo addClick={() => {
+                <AddNewBotanicalInfo addClick={() => {
                     setSelectedBotanicalInfo(undefined);
                     setAddPlantOpen(true);
                 }}

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -32,7 +32,8 @@ function StatsSection(props: {
 
 function Stats(props: {
     requestor: AxiosInstance,
-    visibility: boolean;
+    visibility: boolean,
+    printError: (err: any) => void;
 }) {
     const [expanded, setExpanded] = useState<boolean>(true);
     const [totalEvents, setTotalEvents] = useState<number>(0);
@@ -43,13 +44,17 @@ function Stats(props: {
     useEffect(() => {
         if (props.visibility) {
             props.requestor.get("diary/entry/_count")
-                .then((res) => setTotalEvents(res.data));
+                .then((res) => setTotalEvents(res.data))
+                .catch((err) => props.printError(err));
             props.requestor.get("plant/_count")
-                .then((res) => setTotalPlants(res.data));
+                .then((res) => setTotalPlants(res.data))
+                .catch((err) => props.printError(err));
             props.requestor.get("plant/_countBotanicalInfo")
-                .then((res) => setTotalBotanicalInfo(res.data));
+                .then((res) => setTotalBotanicalInfo(res.data))
+                .catch((err) => props.printError(err));
             props.requestor.get("image/entity/_count")
-                .then((res) => setTotalPhotos(res.data));
+                .then((res) => setTotalPhotos(res.data))
+                .catch((err) => props.printError(err));
         }
     });
 
@@ -126,10 +131,11 @@ function Stats(props: {
     );
 }
 
-// TODO make stats responsive on changes
+
 export default function Settings(props: {
     requestor: AxiosInstance,
-    visibility: boolean;
+    visibility: boolean,
+    printError: (err: any) => void;
 }) {
     let navigate: NavigateFunction = useNavigate();
     const [version, setVersion] = useState<string>();
@@ -141,7 +147,8 @@ export default function Settings(props: {
 
     const getVersion = (): void => {
         props.requestor.get("/info/version")
-            .then((res) => setVersion(res.data));
+            .then((res) => setVersion(res.data))
+            .catch((err) => props.printError(err));
     };
 
     useEffect(() => {
@@ -154,7 +161,11 @@ export default function Settings(props: {
         flexDirection: "column",
     }}>
 
-        <Stats requestor={props.requestor} visibility={props.visibility}/>
+        <Stats
+            requestor={props.requestor}
+            visibility={props.visibility}
+            printError={props.printError}
+        />
         <Box
             sx={{
                 backgroundColor: "background.paper",


### PR DESCRIPTION
This PR introduces lazy load for plant images in the homepage window.
Before this, all plant images were loaded at the same time, resulting in a lot of background processing actions.
After this PR the images are loaded only when visible for the first time in the carousel.

Also:
- Improve error handling