### PR TITLE
Add lazy load for plant images in homepage

### DIFF
--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -57,6 +57,7 @@ function UserPlantsList(props: {
     printError: (err: AxiosError) => void;
 }) {
     const [plantName, setPlantName] = useState<string>("");
+    const [activeIndex, setActiveIndex] = useState<number>(0);
 
     return (
         <Box>
@@ -98,10 +99,10 @@ function UserPlantsList(props: {
                     clickable: true,
                 }}
                 modules={[Pagination, Virtual, FreeMode]}
-                className="mySwiper"
                 slidesPerView={"auto"}
                 spaceBetween={30}
                 centeredSlides={true}
+                onActiveIndexChange={(swiper) => setActiveIndex(swiper.activeIndex)}
             >
                 {
                     props.plants.filter(
@@ -117,6 +118,7 @@ function UserPlantsList(props: {
                                     key={entity.id}
                                     requestor={props.requestor}
                                     onClick={() => props.gotoDetails(entity)}
+                                    active={Math.abs(activeIndex - index) <= 1}
                                     printError={props.printError}
                                 />
                             </SwiperSlide>;

--- a/frontend/src/components/UserPlant.tsx
+++ b/frontend/src/components/UserPlant.tsx
@@ -9,10 +9,12 @@ export default function UserPlant(props: {
     style?: {},
     requestor: AxiosInstance,
     onClick: () => void,
+    active: boolean,
     printError: (err: any) => void;
 }) {
     const [imageLoaded, setImageLoaded] = useState<boolean>(false);
     const [imgSrc, setImgSrc] = useState<string>();
+    const [wasRenderedOnce, setWasRenderedOnce] = useState<boolean>(false);
 
     const setImageSrc = (): void => {
         getBotanicalInfoImg(props.requestor, props.entity.botanicalInfo.imageUrl)
@@ -35,6 +37,16 @@ export default function UserPlant(props: {
     };
 
     useEffect(() => {
+        if (props.active && !wasRenderedOnce) {
+            setImageSrc();
+        }
+    }, [props.active]);
+
+    useEffect(() => {
+        if (props.active) {
+            setWasRenderedOnce(true);
+        }
+    }, [props.active]);
 
     return (
         <Box
@@ -50,21 +62,29 @@ export default function UserPlant(props: {
             }}
             style={props.style}>
             {
-                !imageLoaded &&
-                <Skeleton variant="rounded" animation="wave" sx={{ width: "100%", height: "80%" }} />
+                (!imageLoaded || !wasRenderedOnce) &&
+                <Skeleton
+                    variant="rounded"
+                    animation="wave"
+                    sx={{ width: "100%", height: "80%" }}
+                />
             }
-            <img
-                src={imgSrc}
-                onLoad={() => setImageLoaded(true)}
-                style={{
-                    width: "100%",
-                    height: "80%",
-                    objectFit: "cover",
-                    borderRadius: "10px",
-                    visibility: imageLoaded ? "initial" : "hidden",
-                    marginBottom: "5px",
-                }}
-            />
+            {
+                imageLoaded && wasRenderedOnce &&
+                <img
+                    src={imgSrc}
+                    onLoad={() => setImageLoaded(true)}
+                    style={{
+                        width: "100%",
+                        height: "80%",
+                        objectFit: "cover",
+                        borderRadius: "10px",
+                        visibility: imageLoaded ? "initial" : "hidden",
+                        marginBottom: "5px",
+                    }}
+                    loading="lazy"
+                />
+            }
             <Typography
                 noWrap
                 variant="body1"


### PR DESCRIPTION
This PR introduces lazy load for plant images in the homepage window.
Before this, all plant images were loaded at the same time, resulting in a lot of background processing actions.
After this PR the images are loaded only when visible for the first time in the carousel.