### PR TITLE
Add event log view and "add log" possibility in the `Plant Details` window

### DIFF
--- a/frontend/src/components/AddLogEntry.tsx
+++ b/frontend/src/components/AddLogEntry.tsx
@@ -10,7 +10,7 @@ import {
     useTheme,
 } from "@mui/material";
 import { AxiosError, AxiosInstance } from "axios";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { diaryEntry, plant } from "../interfaces";
 import { GrClose } from "react-icons/gr";
 import { titleCase } from "../common";
@@ -29,6 +29,7 @@ export default function AddLogEntry(props: {
     open: boolean,
     setOpen: (arg: boolean) => void,
     updateLog: (arg: diaryEntry) => void,
+    addForPlant?: plant;
 }) {
     const [date, setDate] = useState<Dayjs | null>(dayjs(new Date()));
     const [selectedPlantName, setSelectedPlantName] = useState<string[]>([]);
@@ -114,6 +115,15 @@ export default function AddLogEntry(props: {
         props.setOpen(false);
     };
 
+
+    useEffect(() => {
+        if (props.addForPlant != undefined) {
+            setSelectedPlantName([props.addForPlant?.personalName]);
+        } else {
+            setSelectedPlantName([]);
+        }
+    }, [props.addForPlant, props.open]);
+
     return (
         <Drawer
             anchor={"bottom"}
@@ -154,6 +164,7 @@ export default function AddLogEntry(props: {
                         disablePortal
                         multiple
                         options={props.plants.map(pl => pl.personalName)}
+                        disabled={props.addForPlant != undefined}
                         value={selectedPlantName}
                         onChange={(_event: any, newValue: readonly string[]) => changePlantName(newValue)}
                         fullWidth
@@ -162,7 +173,7 @@ export default function AddLogEntry(props: {
                             return (
                                 <Typography
                                     noWrap={true}
-                                    color="textPrimary"
+                                    color={props.addForPlant === undefined ? "textPrimary" : "text.disabled"}
                                 >
                                     {renderedValues}
                                 </Typography>

--- a/frontend/src/components/AllLogs.tsx
+++ b/frontend/src/components/AllLogs.tsx
@@ -14,7 +14,8 @@ function Filters(props: {
     plants: plant[],
     setFilteredPlantIds: (ids: number[]) => void,
     eventTypes: string[],
-    setFilteredEventType: (types: string[]) => void;
+    setFilteredEventType: (types: string[]) => void,
+    plantFiltered: boolean;
 }) {
     const [selectedFilteredEntitiyNames, setSelectedFilteredEntitiyNames] = useState<string[]>([]);
     const [selectedFilteredEventTypes, setSelectedFilteredEventTypes] = useState<string[]>([]);
@@ -57,57 +58,68 @@ function Filters(props: {
                             visibility: selectedFilteredEntitiyNames.length > 0 || selectedFilteredEventTypes.length > 0 ? "visible" : "hidden",
                         }}
                         onClick={() => {
-                            setSelectedFilteredEntitiyNames([]);
-                            props.setFilteredPlantIds([]);
                             setSelectedFilteredEventTypes([]);
                             props.setFilteredEventType([]);
+                            if (!props.plantFiltered) {
+                                setSelectedFilteredEntitiyNames([]);
+                                props.setFilteredPlantIds([]);
+                            }
                         }}
                     />
                 </Box>
             </AccordionSummary>
-            <AccordionDetails sx={{ display: "flex", gap: "10px", justifyContent: "center" }}>
-                <FormControl fullWidth>
-                    <Autocomplete
-                        disableCloseOnSelect
-                        disablePortal
-                        multiple
-                        options={props.plants.map(pl => pl.personalName)}
-                        value={selectedFilteredEntitiyNames}
-                        onChange={(_event: any, newValue: readonly string[]) => {
-                            let selectedIds = props.plants.filter(pl => newValue.includes(pl.personalName)).map(pl => pl.id);
-                            props.setFilteredPlantIds(selectedIds);
-                            setSelectedFilteredEntitiyNames(Array.from(newValue));
-                        }}
-                        renderTags={(selected) => {
-                            let renderedValues = selected.join(", ");
-                            return (
-                                <Typography
-                                    noWrap={true}
-                                    color="textPrimary"
-                                >
-                                    {renderedValues}
-                                </Typography>
-                            );
-                        }}
-                        sx={{
-                            ".MuiAutocomplete-inputRoot": {
-                                flexWrap: "nowrap !important",
-                            }
-                        }}
-                        renderOption={(props, option, { selected }) => (
-                            <li {...props}>
-                                <Checkbox
-                                    icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-                                    checkedIcon={<CheckBoxIcon fontSize="small" />}
-                                    style={{ marginRight: 8 }}
-                                    checked={selected}
-                                />
-                                {titleCase(option)}
-                            </li>
-                        )}
-                        renderInput={(params) => <TextField {...params} label="Plant" fullWidth />}
-                    />
-                </FormControl>
+            <AccordionDetails
+                sx={{
+                    display: "flex",
+                    gap: "10px",
+                    justifyContent: "center"
+                }}
+            >
+                {
+                    !props.plantFiltered &&
+                    <FormControl fullWidth>
+                        <Autocomplete
+                            disableCloseOnSelect
+                            disablePortal
+                            multiple
+                            options={props.plants.map(pl => pl.personalName)}
+                            value={selectedFilteredEntitiyNames}
+                            onChange={(_event: any, newValue: readonly string[]) => {
+                                let selectedIds = props.plants.filter(pl => newValue.includes(pl.personalName)).map(pl => pl.id);
+                                props.setFilteredPlantIds(selectedIds);
+                                setSelectedFilteredEntitiyNames(Array.from(newValue));
+                            }}
+                            renderTags={(selected) => {
+                                let renderedValues = selected.join(", ");
+                                return (
+                                    <Typography
+                                        noWrap={true}
+                                        color="textPrimary"
+                                    >
+                                        {renderedValues}
+                                    </Typography>
+                                );
+                            }}
+                            sx={{
+                                ".MuiAutocomplete-inputRoot": {
+                                    flexWrap: "nowrap !important",
+                                }
+                            }}
+                            renderOption={(props, option, { selected }) => (
+                                <li {...props}>
+                                    <Checkbox
+                                        icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+                                        checkedIcon={<CheckBoxIcon fontSize="small" />}
+                                        style={{ marginRight: 8 }}
+                                        checked={selected}
+                                    />
+                                    {titleCase(option)}
+                                </li>
+                            )}
+                            renderInput={(params) => <TextField {...params} label="Plant" fullWidth />}
+                        />
+                    </FormControl>
+                }
                 <FormControl fullWidth>
                     <Autocomplete
                         disableCloseOnSelect
@@ -161,7 +173,8 @@ export default function AllLogs(props: {
     plants: plant[],
     openEditEvent: (arg: diaryEntry) => void,
     printError: (err: any) => void,
-    active: boolean;
+    active: boolean,
+    filterByPlant?: plant;
 }) {
     const pageSize = 5;
     const [entities, setEntities] = useState<diaryEntry[]>([]);
@@ -258,6 +271,9 @@ export default function AllLogs(props: {
 
     useEffect(() => {
         setPageNo(0);
+        if (props.filterByPlant != undefined) {
+            setFilteredPlantId([props.filterByPlant.id]);
+        }
     }, []);
 
     const myRef = useRef<Element>();
@@ -275,6 +291,7 @@ export default function AllLogs(props: {
                     setFilteredPlantIds={setFilteredPlantId}
                     eventTypes={props.eventTypes}
                     setFilteredEventType={setFilteredEventType}
+                    plantFiltered={props.filterByPlant !== undefined}
                 />
 
                 {/*

--- a/frontend/src/components/BottomBar.tsx
+++ b/frontend/src/components/BottomBar.tsx
@@ -10,12 +10,10 @@ import {
 import { FaUser } from "react-icons/fa";
 import { IconType } from "react-icons/lib";
 import "../style/BottomBar.scss";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Fab } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import { AxiosInstance } from "axios";
-import AddLogEntry from "./AddLogEntry";
-import { diaryEntry, plant } from "../interfaces";
 
 function BottomBarSection(props: {
     iconDisabled: IconType,
@@ -37,7 +35,7 @@ function BottomBarSection(props: {
             }}
             onClick={() => {
                 if (props.active) {
-                    window.scrollTo({top: 0, left: 0, behavior: "auto"});
+                    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
                     setToggle(false);
                     setTimeout(() => {
                         setToggle(true);
@@ -61,13 +59,8 @@ export default function BottomBar(props: {
     activeTab: number,
     setActiveTab: (arg: number) => void,
     requestor: AxiosInstance,
-    eventTypes: string[],
-    plants: plant[],
-    updateLogEntries: (arg: diaryEntry) => void,
-}
-) {
-    const [addDiaryLogOpen, setAddDiaryLogOpen] = useState<boolean>(false);
-
+    openAddLogEntry: () => void,
+}) {
     return (
         <Box
             boxShadow={.5}
@@ -84,19 +77,10 @@ export default function BottomBar(props: {
                 color: "primary.main",
                 alignItems: "center",
                 padding: "10px",
-                borderRadius: "50px", //"20px 20px 0 0",
+                borderRadius: "50px",
                 zIndex: 10,
             }}
         >
-
-            <AddLogEntry
-                requestor={props.requestor}
-                eventTypes={props.eventTypes}
-                plants={props.plants}
-                open={addDiaryLogOpen}
-                setOpen={setAddDiaryLogOpen}
-                updateLog={props.updateLogEntries}
-            />
 
             <BottomBarSection
                 setActive={() => props.setActiveTab(0)}
@@ -117,7 +101,7 @@ export default function BottomBar(props: {
                     position: "relative",
                     top: "-10px"
                 }}
-                onClick={() => setAddDiaryLogOpen(true)}
+                onClick={props.openAddLogEntry}
             >
                 <AddIcon />
             </Fab>

--- a/frontend/src/components/PlantDetails.tsx
+++ b/frontend/src/components/PlantDetails.tsx
@@ -4,7 +4,7 @@ import ArrowBackIosNewOutlinedIcon from '@mui/icons-material/ArrowBackIosNewOutl
 import AddAPhotoOutlinedIcon from '@mui/icons-material/AddAPhotoOutlined';
 import EventOutlinedIcon from '@mui/icons-material/EventOutlined';
 import Link from '@mui/material/Link';
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { AxiosInstance } from "axios";
 import { alpha } from "@mui/material";
 import { Swiper, SwiperSlide } from "swiper/react";
@@ -14,17 +14,6 @@ import "swiper/css/pagination";
 import 'swiper/css/virtual';
 import "swiper/css/free-mode";
 import { getBotanicalInfoImg } from "../common";
-
-function AllPlantLog(props: {
-    requestor: AxiosInstance,
-
-}) {
-    return (
-        <>
-        </>
-    );
-};
-
 
 function PlantImage(props: {
     imgId: number,
@@ -82,7 +71,8 @@ function Bottombar(props: {
     visible: boolean,
     entity?: plant,
     addUploadedImgs: (arg: number) => void,
-    printError: (err: any) => void;
+    printError: (err: any) => void,
+    openAddLogEntry: () => void;
 }) {
     const addEntityImage = (toUpload: File): void => {
         let formData = new FormData();
@@ -127,6 +117,7 @@ function Bottombar(props: {
                         padding: "15px",
                     }}
                     startIcon={<EventOutlinedIcon />}
+                    onClick={props.openAddLogEntry}
                 >
                     Add event
                 </Button>
@@ -275,8 +266,6 @@ function PlantHeader(props: {
                     }
                 </Swiper>
             }
-
-
         </Box>
     );
 }
@@ -285,11 +274,11 @@ function PlantOverview(props: {
     entity?: plant,
     visible: boolean;
 }) {
+
     return (
         <Box
             sx={{
-                visibility: props.visible ? "visible" : "hidden",
-                display: "flex",
+                display: props.visible ? "flex" : "none",
                 flexDirection: "column",
                 gap: "20px",
                 marginTop: "20px",
@@ -345,20 +334,29 @@ export default function PlantDetails(props: {
     close: () => void;
     entity?: plant,
     requestor: AxiosInstance,
-    printError: (err: any) => void;
+    printError: (err: any) => void,
+    allLogsComponent: React.JSX.Element,
+    filterByPlant: (arg?: plant) => void;
+    openAddLogEntry: () => void,
 }) {
     const [selectedTab, setSelectedTab] = useState<number>(0);
     const [bufferUploadedImgsIds, setBufferedUploadedImgsIds] = useState<number[]>([]);
 
     useEffect(() => {
         setBufferedUploadedImgsIds([]);
+        if (props.open) {
+            props.filterByPlant(props.entity);
+        }
     }, [props.open]);
 
     return (
         <Drawer
             anchor={"bottom"}
             open={props.open}
-            onClose={props.close}
+            onClose={() => {
+                props.filterByPlant(undefined);
+                props.close();
+            }}
         >
 
             <Box
@@ -372,7 +370,10 @@ export default function PlantDetails(props: {
                     zIndex: 2,
                     padding: "5px",
                 }}
-                onClick={props.close}
+                onClick={() => {
+                    props.filterByPlant(undefined);
+                    props.close();
+                }}
             >
                 <ArrowBackIosNewOutlinedIcon />
             </Box>
@@ -430,7 +431,21 @@ export default function PlantDetails(props: {
                         <Tab label="Events" />
                     </Tabs>
 
-                    <PlantOverview entity={props.entity} visible={selectedTab === 0} />
+                    <PlantOverview
+                        entity={props.entity}
+                        visible={selectedTab === 0}
+                    />
+
+                    <Box sx={{
+                        display: selectedTab === 1 ? "initial" : "none",
+                    }}>
+                        {
+                            React.cloneElement(props.allLogsComponent, {
+                                filterByPlant: props.entity,
+                                active: selectedTab === 1,
+                            })
+                        }
+                    </Box>
                 </Box>
                 <Bottombar
                     requestor={props.requestor}
@@ -440,6 +455,7 @@ export default function PlantDetails(props: {
                         setBufferedUploadedImgsIds([arg, ...bufferUploadedImgsIds]);
                     }}
                     printError={props.printError}
+                    openAddLogEntry={props.openAddLogEntry}
                 />
             </Box>
         </Drawer>


### PR DESCRIPTION
This PR adds the possibility of viewing the specific plant's log in the `Plant Details` window.
It also adds the feature of creating a new log entry clicking on the `Add event` button.

Before the PR:
<p align="center">
<img src="https://github.com/MDeLuise/plant-it/assets/66636702/a4c1716c-c39a-4fb4-b948-1359ffdb9b63" width="45%"/>
</p>

After the PR:
<p align="center">
<img src="https://github.com/MDeLuise/plant-it/assets/66636702/b8ef581e-8392-4a0b-bd79-bcf2ec40194c" width="45%"/>
<img src="https://github.com/MDeLuise/plant-it/assets/66636702/67410637-ab64-4dbd-91b1-85c72076232a" width="45%"/>
</p>
