### PR TITLE
Fix event note not updating

### DIFF
--- a/frontend/src/components/EditEvent.tsx
+++ b/frontend/src/components/EditEvent.tsx
@@ -120,7 +120,7 @@ export default function EditEvent(props: {
         setSelectedPlantName(props.toEdit?.diaryTargetPersonalName);
         setSelectedEventType(props.toEdit?.type);
         setDate(dayjs(props.toEdit?.date));
-        setNote(props.toEdit?.note);
+        setNote(props.toEdit?.note !== null ? props.toEdit?.note : "");
         setEdit(false);
         setConfirmDialogCallback(() => deleteEvent);
     }, [props.toEdit]);
@@ -222,8 +222,8 @@ export default function EditEvent(props: {
                     </Box>
 
                     <Box sx={{ width: "100%" }}>
+                    <InputLabel>Note</InputLabel>
                         <TextField
-                            label="Note"
                             multiline
                             rows={4}
                             onChange={(event) => setNote(event.target.value)}


### PR DESCRIPTION
This PR fixes an issue that sometime prevents the `note` field to update when viewing log events.

