### PR TITLE
Fix add plant with not loadable image

### DIFF
--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -53,3 +53,18 @@ export const getErrMessage = (err: any): string => {
     }
     return "Some error occurred";
 };
+
+
+export const imgToBase64 = (url: string, callback: (arg: string) => void): void => {
+    var xhr = new XMLHttpRequest();
+    xhr.onload = function () {
+        var reader = new FileReader();
+        reader.onloadend = function () {
+            callback((reader.result as string).replace("data:image/png;base64,", ""));
+        };
+        reader.readAsDataURL(xhr.response);
+    };
+    xhr.open('GET', url);
+    xhr.responseType = 'blob';
+    xhr.send();
+};

--- a/frontend/src/components/AddPlant.tsx
+++ b/frontend/src/components/AddPlant.tsx
@@ -6,6 +6,7 @@ import dayjs, { Dayjs } from "dayjs";
 import { LocalizationProvider, DatePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import AddPhotoAlternateOutlinedIcon from '@mui/icons-material/AddPhotoAlternateOutlined';
+import { getBotanicalInfoImg, imgToBase64 } from "../common";
 
 export default function AddPlant(props: {
     requestor: AxiosInstance,
@@ -34,7 +35,20 @@ export default function AddPlant(props: {
                 setDownloadedImg(res.data);
                 setImageDownloaded(true);
             })
-            .catch((err) => props.printError(err));
+            .catch((err) => {
+                getBotanicalInfoImg(props.requestor, undefined)
+                    .then((res) => {
+                        console.error(err);
+                        imgToBase64(res, (arg: string) => {
+                            setDownloadedImg(arg);
+                        });
+                        setImageDownloaded(true);
+                    })
+                    .catch((err) => {
+                        console.log(err);
+                        props.printError(`Cannot load image with id ${props.entity?.imageId}`);
+                    });
+            });
     };
 
     const setAbsoluteImageUrl = (imageUrl: string | undefined, publicUrl: string): string => {

--- a/frontend/src/components/PlantDetails.tsx
+++ b/frontend/src/components/PlantDetails.tsx
@@ -13,8 +13,7 @@ import "swiper/css";
 import "swiper/css/pagination";
 import 'swiper/css/virtual';
 import "swiper/css/free-mode";
-import { getBotanicalInfoImg } from "../common";
-import { BsPersonPlus } from "react-icons/bs";
+import { getBotanicalInfoImg, imgToBase64 } from "../common";
 
 function PlantImage(props: {
     imgId: string,
@@ -26,20 +25,6 @@ function PlantImage(props: {
     const [loaded, setLoaded] = useState<boolean>(false);
     const [imgBase64, setImgBase64] = useState<string>();
 
-    const imgToBase64 = (url: string, callback: (arg: any) => void): void => {
-        var xhr = new XMLHttpRequest();
-        xhr.onload = function () {
-            var reader = new FileReader();
-            reader.onloadend = function () {
-                callback(reader.result);
-            };
-            reader.readAsDataURL(xhr.response);
-        };
-        xhr.open('GET', url);
-        xhr.responseType = 'blob';
-        xhr.send();
-    };
-
     const getImgBase64 = (): void => {
         props.requestor.get(`/image/content/${props.imgId}`)
             .then((res) => {
@@ -50,9 +35,8 @@ function PlantImage(props: {
                 props.printError(err);
                 getBotanicalInfoImg(props.requestor, undefined)
                     .then((res) => {
-                        console.debug(res);
                         imgToBase64(res, (arg: string) => {
-                            setImgBase64(arg.replace("data:image/png;base64,", ""));
+                            setImgBase64(arg);
                             setLoaded(true);
                         });
                     })


### PR DESCRIPTION
This PR fixes a problem that occurs when trying to add a plant that uses a scientific classification that has an image that could not be loaded (e.g. because removed).
The scientific classification image result in infinite loading rendering, and a loop of error message are displayed.