### PR TITLE
Add persistent database storage for mysql

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     image: mysql:8.0
     restart: always
     env_file: backend.env
+    volumes:
+      - "./db:/var/lib/mysql"
 
   cache:
     image: redis:7.2.1


### PR DESCRIPTION
<!--
Before you create a new PR, please consider:
1) DO NOT include translations in your PR. Only English US sentences.
Thanks.
-->

This PR adds a bind mount (similar to the one used for the upload dir) for the mysql database container to enable persistent storage.

Without a persistent storage solution, database information would get lost everytime the container is removed.