### PR TITLE
Fix newer custom botanical info available only after component refresh

### DIFF
--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -165,11 +165,11 @@ function DiaryEntriesList(props: {
 
 export default function Home(props: { isLoggedIn: () => boolean, requestor: AxiosInstance; }) {
     let navigate: NavigateFunction = useNavigate();
+    const logPageSize = 5;
     const [plants, setPlants] = useState<plant[]>([]);
     const [logEntries, setLogEntries] = useState<diaryEntry[]>([]);
     const [activeTab, setActiveTab] = useState<number>(0);
     const [allEventTypes, setAllEventTypes] = useState<string[]>([]);
-    const logPageSize = 5;
     const [editEventVisible, setEditEventVisible] = useState<boolean>(false);
     const [eventToEdit, setEventToEdit] = useState<diaryEntry>();
     const [plantDetails, setPlantDetails] = useState<{ plant?: plant, open: boolean; }>({ open: false });

--- a/frontend/src/components/SearchPage.tsx
+++ b/frontend/src/components/SearchPage.tsx
@@ -184,7 +184,7 @@ export default function SearchPage(props: {
 
     const retrieveBotanicalInfos = (): void => {
         let backendUrl: string;
-        if (scientificName == "") {
+        if (scientificName === "") {
             backendUrl = "botanical-info";
         } else {
             backendUrl = `botanical-info/partial/${scientificName}`;
@@ -214,7 +214,8 @@ export default function SearchPage(props: {
                 requestor={props.requestor}
                 open={addPlantOpen}
                 close={() => setAddPlantOpen(false)}
-                botanicalInfo={selectedBotanicalInfo}
+                botanicalInfoToAdd={selectedBotanicalInfo}
+                botanicalInfos={botanicalInfos}
                 plants={props.plants}
                 name={scientificName}
                 printError={props.printError}
@@ -265,7 +266,7 @@ export default function SearchPage(props: {
                     </>
                 }
                 {
-                    botanicalInfos.map((botanicalInfo, index) => {
+                    botanicalInfos.map(botanicalInfo => {
                         return <BotanicalEntity
                             entity={botanicalInfo}
                             requestor={props.requestor}
@@ -274,17 +275,19 @@ export default function SearchPage(props: {
                                 setAddPlantOpen(true);
                             }}
                             addEntity={(en: plant) => props.plants.push(en)}
-                            key={index}
+                            key={botanicalInfo.id}
                             printError={props.printError}
                         />;
                     })
                 }
-                <AddNewBotanicalInfo addClick={() => {
-                    setSelectedBotanicalInfo(undefined);
-                    setAddPlantOpen(true);
-                }}
+                <AddNewBotanicalInfo
+                    addClick={() => {
+                        setSelectedBotanicalInfo(undefined);
+                        setAddPlantOpen(true);
+                    }}
                     searchedTerm={scientificName}
-                    requestor={props.requestor} />
+                    requestor={props.requestor}
+                />
             </Box>
         </Box>
     );


### PR DESCRIPTION
This PR fixes #49, i.e. when a new custom botanical info is created, that will be available immediately without requiring a page refresh.