### PR TITLE
Introducing synonyms field for user-created species

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.github.mdeluise</groupId>
     <artifactId>plant-it</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <name>Plant it</name>
     <description>Gardening companion app</description>
     <properties>

--- a/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfo.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfo.java
@@ -11,10 +11,14 @@ import com.github.mdeluise.plantit.image.BotanicalInfoImage;
 import com.github.mdeluise.plantit.image.ImageTarget;
 import com.github.mdeluise.plantit.plant.Plant;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -35,6 +39,10 @@ public class BotanicalInfo implements Serializable, ImageTarget {
     // https://landscapeplants.oregonstate.edu/scientific-plant-names-binomial-nomenclature
     @NotBlank
     private String scientificName;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "synonyms")
+    @Column(name = "synonym_value")
+    private Set<String> synonyms = new HashSet<>();
     private String family;
     private String genus;
     private String species;
@@ -71,6 +79,16 @@ public class BotanicalInfo implements Serializable, ImageTarget {
 
     public void setScientificName(String scientificName) {
         this.scientificName = scientificName;
+    }
+
+
+    public Set<String> getSynonyms() {
+        return synonyms;
+    }
+
+
+    public void setSynonyms(Set<String> synonyms) {
+        this.synonyms = synonyms;
     }
 
 
@@ -181,7 +199,7 @@ public class BotanicalInfo implements Serializable, ImageTarget {
 
 
     public boolean isPlantCareEmpty() {
-        return plantCareInfo.isAllNull();
+        return getPlantCareInfo().isAllNull();
     }
 
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfoDTO.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfoDTO.java
@@ -1,6 +1,7 @@
 package com.github.mdeluise.plantit.botanicalinfo;
 
 import java.util.Objects;
+import java.util.Set;
 
 import com.github.mdeluise.plantit.botanicalinfo.care.PlantCareInfoDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,6 +12,8 @@ public class BotanicalInfoDTO {
     private Long id;
     @Schema(description = "Scientific name of the botanical info.")
     private String scientificName;
+    @Schema(description = "Synonyms of the botanical info.")
+    private Set<String> synonyms;
     @Schema(description = "Family of the botanical info.")
     private String family;
     @Schema(description = "Genus of the botanical info.")
@@ -46,6 +49,16 @@ public class BotanicalInfoDTO {
 
     public void setScientificName(String scientificName) {
         this.scientificName = scientificName;
+    }
+
+
+    public Set<String> getSynonyms() {
+        return synonyms;
+    }
+
+
+    public void setSynonyms(Set<String> synonyms) {
+        this.synonyms = synonyms;
     }
 
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfoRepository.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfoRepository.java
@@ -1,12 +1,26 @@
 package com.github.mdeluise.plantit.botanicalinfo;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BotanicalInfoRepository extends JpaRepository<BotanicalInfo, Long> {
 
     List<BotanicalInfo> findByScientificNameContainsIgnoreCase(String partialScientificName);
+
+    @Query("SELECT b FROM BotanicalInfo b JOIN b.synonyms s WHERE LOWER(s) LIKE LOWER(:synonym)")
+    List<BotanicalInfo> findBySynonymsContainsIgnoreCase(@Param("synonym") String synonym);
+
+    default List<BotanicalInfo> getByScientificNameOrSynonym(String search) {
+        final Set<BotanicalInfo> result = new HashSet<>();
+        result.addAll(findByScientificNameContainsIgnoreCase(search));
+        result.addAll(findBySynonymsContainsIgnoreCase(search));
+        return result.stream().toList();
+    }
 
     List<BotanicalInfo> findAll();
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfoService.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfoService.java
@@ -45,9 +45,10 @@ public class BotanicalInfoService {
         logger.debug(String.format("Search for DB saved botanical info matching '%s' scientific name (max size %s)",
                                    partialScientificName, size));
         final List<BotanicalInfo> result =
-            botanicalInfoRepository.findByScientificNameContainsIgnoreCase(partialScientificName).stream().filter(
-                                       botanicalInfo -> botanicalInfo.isAccessibleToUser(authenticatedUserService.getAuthenticatedUser()))
-                                   .limit(size).toList();
+            botanicalInfoRepository.getByScientificNameOrSynonym(partialScientificName).stream().filter(
+                botanicalInfo -> botanicalInfo.isAccessibleToUser(authenticatedUserService.getAuthenticatedUser()))
+                                   .limit(size)
+                                   .toList();
         return new HashSet<>(result.subList(0, Math.min(size, result.size())));
     }
 
@@ -133,6 +134,7 @@ public class BotanicalInfoService {
         toUpdate.setSpecies(updated.getSpecies());
         toUpdate.setScientificName(updated.getScientificName());
         toUpdate.setPlantCareInfo(updated.getPlantCareInfo());
+        toUpdate.setSynonyms(updated.getSynonyms());
         return botanicalInfoRepository.save(toUpdate);
     }
 
@@ -145,6 +147,7 @@ public class BotanicalInfoService {
         userCreatedCopy.setSpecies(toCopy.getSpecies());
         userCreatedCopy.setScientificName(toCopy.getScientificName());
         userCreatedCopy.setPlantCareInfo(toCopy.getPlantCareInfo());
+        userCreatedCopy.setSynonyms(new HashSet<>(toCopy.getSynonyms()));
 
         userCreatedCopy = save(userCreatedCopy);
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/care/PlantCareInfoDTOConverter.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/care/PlantCareInfoDTOConverter.java
@@ -13,6 +13,9 @@ public class PlantCareInfoDTOConverter extends AbstractDTOConverter<PlantCareInf
 
     @Override
     public PlantCareInfo convertFromDTO(PlantCareInfoDTO dto) {
+        if (dto == null) {
+            return new PlantCareInfo();
+        }
         return modelMapper.map(dto, PlantCareInfo.class);
     }
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/plantinfo/trafle/TrefleMigrator.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plantinfo/trafle/TrefleMigrator.java
@@ -1,5 +1,7 @@
 package com.github.mdeluise.plantit.plantinfo.trafle;
 
+import java.util.Set;
+
 import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfo;
 import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfoCreator;
 import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfoRepository;
@@ -12,7 +14,8 @@ import org.springframework.stereotype.Service;
 /**
  * This class is used to add new info in the existing species on system version update.
  * v0.1.0: Botanical Info object has new `external_id` field.
- * v0.1.1: Botanical Info object has new `PlantCareInfo` field.
+ * v0.2.0: Botanical Info object has new `PlantCareInfo` field.
+ * v0.2.0: Botanical Info object has new `synonyms` field.
  */
 @Service
 public class TrefleMigrator {
@@ -45,6 +48,9 @@ public class TrefleMigrator {
             if (botanicalInfo.getExternalId() != null && botanicalInfo.isPlantCareEmpty()) {
                 logger.info("external_id field found, updating care info...");
                 fillMissingExternalCareInfo(botanicalInfo);
+            } else if (botanicalInfo.getExternalId() != null && botanicalInfo.getSynonyms().isEmpty()) {
+                logger.info("external_id field found, updating synonyms...");
+                fillMissingExternalSynonyms(botanicalInfo);
             } else if (botanicalInfo.getExternalId() == null) {
                 logger.info("external_id field not found.");
             } else {
@@ -72,5 +78,14 @@ public class TrefleMigrator {
         }
         final PlantCareInfo plantCareInfo = trefleRequestMaker.getPlantCare(toUpdate);
         toUpdate.setPlantCareInfo(plantCareInfo);
+    }
+
+
+    private void fillMissingExternalSynonyms(BotanicalInfo toUpdate) {
+        if (toUpdate.getExternalId() == null) {
+            return;
+        }
+        final Set<String> synonyms = trefleRequestMaker.getSynonyms(toUpdate);
+        toUpdate.setSynonyms(synonyms);
     }
 }

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -88,7 +88,7 @@ app.version                                 = @project.version@
 users.max                                   = ${USERS_LIMIT:-1}
 trefle.key                                  = ${TREFLE_KEY:}
 upload.location                             = ${UPLOAD_DIR:/tmp/plant-it}
-update_existing                             = ${UPDATE_EXISTING:true}
+update_existing                             = ${UPDATE_EXISTING:false}
 
 
 #

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -84,7 +84,7 @@ app.version                                = @project.version@
 users.max                                  = ${USERS_LIMIT:-1}
 trefle.key                                 = ${TREFLE_KEY:}
 upload.location                            = ${UPLOAD_DIR:/upload-dir}
-update_existing                            = ${UPDATE_EXISTING:true}
+update_existing                            = ${UPDATE_EXISTING:false}
 
 
 #

--- a/backend/src/main/resources/dblogs/changelog/changes/v0-0-0.xml
+++ b/backend/src/main/resources/dblogs/changelog/changes/v0-0-0.xml
@@ -259,6 +259,24 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="createSynonymsTable" author="MDeLuise">
+        <createTable tableName="synonyms">
+            <column name="botanical_info_id" type="bigint">
+                <constraints nullable="false" primaryKey="true" foreignKeyName="fk_synonyms_botanicalInfo"
+                             references="botanical_infos(id)"/>
+            </column>
+            <column name="synonym_value" type="varchar(50)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+        </createTable>
+
+        <addUniqueConstraint
+                columnNames="botanical_info_id, synonym_value"
+                constraintName="synonym_unique"
+                tableName="synonyms"
+        />
+    </changeSet>
+
     <!-- can be removed after update to v0.1.0 -->
     <changeSet id="updateTo0.1.0" author="MDeLuise">
         <preConditions onFail="MARK_RAN">
@@ -294,7 +312,7 @@
     </changeSet>
 
 
-    <!-- can be removed after update to v0.1.1 -->
+    <!-- can be removed after update to v0.2.0 -->
     <changeSet id="updateTo0.1.1" author="MDeLuise">
         <preConditions onFail="MARK_RAN">
             <not>

--- a/backend/src/main/resources/dblogs/changelog/init-dummy-data.xml
+++ b/backend/src/main/resources/dblogs/changelog/init-dummy-data.xml
@@ -15,10 +15,10 @@
         <insert tableName="botanical_infos">
             <column name="id" value="99"/>
             <column name="external_id" value="355135" />
-            <column name="scientific_name" value="Sedum spectabile"/>
+            <column name="scientific_name" value="Hylotelephium spectabile"/>
             <column name="family" value="Crassulaceae"/>
             <column name="genus" value="Hylotelephium"/>
-            <column name="species" value="Sedum spectabile"/>
+            <column name="species" value="Hylotelephium spectabile"/>
             <column name="creator" value="TREFLE"/>
         </insert>
         <insert tableName="botanical_infos">
@@ -43,6 +43,41 @@
             <column name="creator" value="USER"/>
             <column name="user_creator_id" value="99"/>
             <column name="light" value="7" />
+        </insert>
+    </changeSet>
+
+    <changeSet id="insertBotanicalInfoSynonyms" author="MDeLuise">
+        <insert tableName="synonyms">
+            <column name="botanical_info_id" value="98"/>
+            <column name="synonym_value" value="Sedum compressum"/>
+        </insert>
+        <insert tableName="synonyms">
+            <column name="botanical_info_id" value="98"/>
+            <column name="synonym_value" value="Sedum palmeri subsp. rubromarginatum"/>
+        </insert>
+        <insert tableName="synonyms">
+            <column name="botanical_info_id" value="98"/>
+            <column name="synonym_value" value="Sedum palmeri subsp. emarginatum"/>
+        </insert>
+        <insert tableName="synonyms">
+            <column name="botanical_info_id" value="99"/>
+            <column name="synonym_value" value="Anacampseros spectabilis"/>
+        </insert>
+        <insert tableName="synonyms">
+            <column name="botanical_info_id" value="99"/>
+            <column name="synonym_value" value="Sedum spectabile"/>
+        </insert>
+        <insert tableName="synonyms">
+            <column name="botanical_info_id" value="99"/>
+            <column name="synonym_value" value="Iceplant"/>
+        </insert>
+        <insert tableName="synonyms">
+            <column name="botanical_info_id" value="97"/>
+            <column name="synonym_value" value="Foo"/>
+        </insert>
+        <insert tableName="synonyms">
+            <column name="botanical_info_id" value="97"/>
+            <column name="synonym_value" value="Bar"/>
         </insert>
     </changeSet>
 

--- a/backend/src/test/java/com/github/mdeluise/plantit/botanicalinfo/service/BotanicalInfoServiceTest.java
+++ b/backend/src/test/java/com/github/mdeluise/plantit/botanicalinfo/service/BotanicalInfoServiceTest.java
@@ -52,8 +52,7 @@ class BotanicalInfoServiceTest {
         toReturn2.setId(2L);
         final List<BotanicalInfo> toReturn = List.of(toReturn1, toReturn2);
 
-        Mockito.when(botanicalInfoRepository.findByScientificNameContainsIgnoreCase(partialScientificName))
-               .thenReturn(toReturn);
+        Mockito.when(botanicalInfoRepository.getByScientificNameOrSynonym(partialScientificName)).thenReturn(toReturn);
 
         Assertions.assertThat(botanicalInfoService.getByPartialScientificName(partialScientificName, 2))
                   .as("botanical info set is correct").hasSameElementsAs(toReturn);
@@ -70,8 +69,7 @@ class BotanicalInfoServiceTest {
         toReturn2.setId(2L);
         final List<BotanicalInfo> toReturn = List.of(toReturn1, toReturn2);
 
-        Mockito.when(botanicalInfoRepository.findByScientificNameContainsIgnoreCase(partialScientificName))
-               .thenReturn(toReturn);
+        Mockito.when(botanicalInfoRepository.getByScientificNameOrSynonym(partialScientificName)).thenReturn(toReturn);
 
         Assertions.assertThat(botanicalInfoService.getByPartialScientificName(partialScientificName, 1))
                   .as("botanical info set is correct").hasSameElementsAs(List.of(toReturn1));

--- a/frontend/src/components/AddPlant.tsx
+++ b/frontend/src/components/AddPlant.tsx
@@ -13,6 +13,7 @@ import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
 import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
 import SaveAsOutlinedIcon from '@mui/icons-material/SaveAsOutlined';
 import ConfirmDeleteDialog from "./ConfirmDialog";
+import { EditableTextField } from "./EditableTextField";
 
 function AddPlantHeader(props: {
     requestor: AxiosInstance,
@@ -256,6 +257,8 @@ function AddPlantInfo(props: {
                     const botanicalInfoToCreate = {
                         ...updatedBotanicalInfo,
                         creator: props.botanicalInfoToAdd === undefined ? "USER" : "TREFLE",
+                        synonyms: updatedBotanicalInfo!.synonyms,
+                        plantCareInfo: updatedBotanicalInfo?.plantCareInfo ? updatedBotanicalInfo.plantCareInfo : {},
                     } as botanicalInfo;
                     const thumbnail = updatedBotanicalInfoThumbnail.file || updatedBotanicalInfoThumbnail.url || updatedBotanicalInfo?.imageUrl;
                     addNewBotanicalInfo(botanicalInfoToCreate, thumbnail)
@@ -543,6 +546,28 @@ function AddPlantInfo(props: {
             </Box>
         </Box>
 
+        {
+            (props.editModeEnabled || !props.botanicalInfoToAdd || (updatedBotanicalInfo?.synonyms && updatedBotanicalInfo!.synonyms.length > 0)) &&
+            <Box
+                className="plant-detail-section">
+                <Typography variant="h6">
+                    Species info
+                </Typography>
+                <Box className="plant-detail-entry">
+                    <Typography>
+                        Synonyms
+                    </Typography>
+                    <EditableTextField
+                        editable={props.editModeEnabled || !props.botanicalInfoToAdd}
+                        text={updatedBotanicalInfo?.synonyms?.join("; ") || ""}
+                        rows={updatedBotanicalInfo?.synonyms?.length}
+                        onChange={(synonyms) => updatedBotanicalInfo!.synonyms = synonyms.split(";").map(syn => syn.trim())}
+                        style={{ "max-width": "50%" }}
+                    />
+                </Box>
+            </Box>
+        }
+
         <Box
             className="plant-detail-section">
             <Typography variant="h6">
@@ -550,78 +575,78 @@ function AddPlantInfo(props: {
             </Typography>
 
             {
-                (props.editModeEnabled || updatedBotanicalInfo?.plantCareInfo?.light) &&
+                (props.editModeEnabled || !props.botanicalInfoToAdd || updatedBotanicalInfo?.plantCareInfo?.light) &&
                 <Box className="plant-detail-entry">
                     <Typography>
                         Light
                     </Typography>
                     <EditableTextField
-                        editable={props.editModeEnabled}
+                        editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatLightRequirement(updatedBotanicalInfo?.plantCareInfo?.light, props.editModeEnabled)}
                         onChange={(newVal) => updatedBotanicalInfo!.plantCareInfo = { ...updatedBotanicalInfo!.plantCareInfo!, light: getNumberValueOrUndefined(newVal) }}
                     />
                 </Box>
             }
             {
-                (props.editModeEnabled || updatedBotanicalInfo?.plantCareInfo?.humidity) &&
+                (props.editModeEnabled || !props.botanicalInfoToAdd || updatedBotanicalInfo?.plantCareInfo?.humidity) &&
                 <Box className="plant-detail-entry">
                     <Typography>
                         Soil humidity
                     </Typography>
                     <EditableTextField
-                        editable={props.editModeEnabled}
+                        editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatHumidityRequirement(updatedBotanicalInfo?.plantCareInfo?.humidity, props.editModeEnabled)}
                         onChange={(newVal) => updatedBotanicalInfo!.plantCareInfo = { ...updatedBotanicalInfo!.plantCareInfo!, humidity: getNumberValueOrUndefined(newVal) }}
                     />
                 </Box>
             }
             {
-                (props.editModeEnabled || updatedBotanicalInfo?.plantCareInfo?.maxTemp) &&
+                (props.editModeEnabled || !props.botanicalInfoToAdd || updatedBotanicalInfo?.plantCareInfo?.maxTemp) &&
                 <Box className="plant-detail-entry">
                     <Typography>
                         Maximum temperature
                     </Typography>
                     <EditableTextField
-                        editable={props.editModeEnabled}
+                        editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatTemperatureRequirement(updatedBotanicalInfo?.plantCareInfo?.maxTemp, props.editModeEnabled)}
                         onChange={(newVal) => updatedBotanicalInfo!.plantCareInfo = { ...updatedBotanicalInfo!.plantCareInfo!, maxTemp: getNumberValueOrUndefined(newVal) }}
                     />
                 </Box>
             }
             {
-                (props.editModeEnabled || updatedBotanicalInfo?.plantCareInfo?.minTemp) &&
+                (props.editModeEnabled || !props.botanicalInfoToAdd || updatedBotanicalInfo?.plantCareInfo?.minTemp) &&
                 <Box className="plant-detail-entry">
                     <Typography>
                         Minimum temperature
                     </Typography>
                     <EditableTextField
-                        editable={props.editModeEnabled}
+                        editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatTemperatureRequirement(updatedBotanicalInfo?.plantCareInfo?.minTemp, props.editModeEnabled)}
                         onChange={(newVal) => updatedBotanicalInfo!.plantCareInfo = { ...updatedBotanicalInfo!.plantCareInfo!, minTemp: getNumberValueOrUndefined(newVal) }}
                     />
                 </Box>
             }
             {
-                (props.editModeEnabled || updatedBotanicalInfo?.plantCareInfo?.phMax) &&
+                (props.editModeEnabled || !props.botanicalInfoToAdd || updatedBotanicalInfo?.plantCareInfo?.phMax) &&
                 <Box className="plant-detail-entry">
                     <Typography>
                         Maximum ph
                     </Typography>
                     <EditableTextField
-                        editable={props.editModeEnabled}
+                        editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatPh(updatedBotanicalInfo?.plantCareInfo?.phMax)}
                         onChange={(newVal) => updatedBotanicalInfo!.plantCareInfo = { ...updatedBotanicalInfo!.plantCareInfo!, phMax: getNumberValueOrUndefined(newVal) }}
                     />
                 </Box>
             }
             {
-                (props.editModeEnabled || updatedBotanicalInfo?.plantCareInfo?.phMin) &&
+                (props.editModeEnabled || !props.botanicalInfoToAdd || updatedBotanicalInfo?.plantCareInfo?.phMin) &&
                 <Box className="plant-detail-entry">
                     <Typography>
                         Minimum ph
                     </Typography>
                     <EditableTextField
-                        editable={props.editModeEnabled}
+                        editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatPh(updatedBotanicalInfo?.plantCareInfo?.phMin)}
                         onChange={(newVal) => updatedBotanicalInfo!.plantCareInfo = { ...updatedBotanicalInfo!.plantCareInfo!, phMin: getNumberValueOrUndefined(newVal) }}
                     />
@@ -768,6 +793,7 @@ function AddPlantInfo(props: {
                             onClick={() => {
                                 const thumbnail = updatedBotanicalInfoThumbnail.file || updatedBotanicalInfoThumbnail.url || updatedBotanicalInfo?.imageUrl;
                                 if (props.botanicalInfoToAdd === undefined || props.botanicalInfoToAdd.id === null) {
+                                    updatedBotanicalInfo!.creator = "USER";
                                     addNewBotanicalInfo(updatedBotanicalInfo as botanicalInfo, thumbnail)
                                         .then(updatedBIRes => {
                                             setUpdatedBotanicalInfo(updatedBIRes);
@@ -792,40 +818,6 @@ function AddPlantInfo(props: {
             }
         </Box>
     </Box>;
-}
-
-
-function EditableTextField(props: {
-    editable: boolean,
-    text?: string;
-    onChange?: (arg: string) => void;
-}) {
-    const [value, setValue] = useState<string>(props.text || "");
-
-    useEffect(() => {
-        setValue(props.text || "");
-    }, [props.text]);
-
-    return props.editable ?
-        <TextField
-            variant="standard"
-            InputProps={{ disableUnderline: props.editable ? false : true }}
-            disabled={!props.editable}
-            onChange={(e) => {
-                setValue(e.target.value);
-                if (props.onChange != undefined) {
-                    props.onChange(e.target.value);
-                }
-            }}
-            value={value}
-            sx={{
-                color: "black",
-            }}
-        />
-        :
-        <Typography>
-            {props.text}
-        </Typography>;
 }
 
 

--- a/frontend/src/components/EditableTextField.tsx
+++ b/frontend/src/components/EditableTextField.tsx
@@ -1,0 +1,56 @@
+import { TextField, Typography } from "@mui/material";
+import { useState, useEffect } from "react";
+
+export function EditableTextField(props: {
+    editable: boolean,
+    text?: string,
+    maxLength?: number,
+    onChange?: (arg: string) => void,
+    variant?: "body1" | "h6",
+    style?: {},
+    rows?: number;
+}) {
+    const [value, setValue] = useState<string>();
+
+    useEffect(() => {
+        setValue(props.text || "");
+    }, [props.text]);
+
+
+    const renderedText = (arg?: string) => {
+        if (arg === undefined) {
+            return arg;
+        }
+        if (props.maxLength !== undefined && arg.length > props.maxLength) {
+            return arg.substring(0, props.maxLength) + "...";
+        }
+        return arg;
+    }
+
+    return props.editable ?
+        <TextField
+            variant="standard"
+            InputProps={{ disableUnderline: props.editable ? false : true }}
+            disabled={!props.editable}
+            onChange={(e) => {
+                setValue(e.target.value);
+                if (props.onChange != undefined) {
+                    props.onChange(e.target.value);
+                }
+            }}
+            value={value}
+            sx={{
+                ...props.style,
+                color: "black",
+            }}
+        />
+        :
+        <Typography
+            sx={{ ...props.style }}
+            variant={props.variant}
+            //multiline={props.rows ? Math.max(1, props.rows) > 1 : false}
+            //rows={props.rows ? Math.max(1, props.rows) : 1}
+        >
+            {renderedText(props.text)}
+        </Typography>;
+}

--- a/frontend/src/components/PlantDetails.tsx
+++ b/frontend/src/components/PlantDetails.tsx
@@ -26,6 +26,7 @@ import dayjs from "dayjs";
 import CloseIcon from '@mui/icons-material/Close';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ConfirmDeleteDialog from "./ConfirmDialog";
+import { EditableTextField } from "./EditableTextField";
 
 
 function PlantImageFullSize(props: {
@@ -440,55 +441,6 @@ function PlantHeader(props: {
 }
 
 
-function EditableTextField(props: {
-    editable: boolean,
-    text?: string,
-    maxLength?: number,
-    onChange?: (arg: string) => void,
-    variant?: "body1" | "h6",
-    style?: {};
-}) {
-    const [value, setValue] = useState<string>();
-
-    useEffect(() => {
-        setValue(props.text || "");
-    }, [props.text]);
-
-
-    const renderedText = (arg?: string) => {
-        if (arg === undefined) {
-            return arg;
-        }
-        if (props.maxLength !== undefined && arg.length > props.maxLength) {
-            return arg.substring(0, props.maxLength) + "...";
-        }
-        return arg;
-    }
-
-    return props.editable ?
-        <TextField
-            variant="standard"
-            InputProps={{ disableUnderline: props.editable ? false : true }}
-            disabled={!props.editable}
-            onChange={(e) => {
-                setValue(e.target.value);
-                if (props.onChange != undefined) {
-                    props.onChange(e.target.value);
-                }
-            }}
-            value={value}
-            sx={{
-                ...props.style,
-                color: "black",
-            }}
-        />
-        :
-        <Typography sx={{ ...props.style }} variant={props.variant}>
-            {renderedText(props.text)}
-        </Typography>;
-}
-
-
 function ReadMoreReadLess(props: {
     text: string,
     size: number;
@@ -760,6 +712,28 @@ function PlantInfo(props: {
             }
         </Box>
 
+
+        {
+            (!props.editModeEnabled && props.botanicalInfo?.synonyms !== undefined && props.botanicalInfo!.synonyms.length > 0) &&
+            <Box
+                className="plant-detail-section">
+                <Typography variant="h6">
+                    Species info
+                </Typography>
+                <Box className="plant-detail-entry">
+                    <Typography>
+                        Synonyms
+                    </Typography>
+                    <EditableTextField
+                        editable={props.editModeEnabled}
+                        text={props.botanicalInfo?.synonyms?.join("; ") || ""}
+                        rows={props.botanicalInfo?.synonyms.length}
+                        style={{ "max-width": "45%" }}
+                    />
+                </Box>
+            </Box>
+        }
+
         {
             !props.editModeEnabled &&
             <Box
@@ -944,73 +918,78 @@ function PlantInfo(props: {
             </Box>
         </Box>
 
-        <Box
-            className="plant-detail-section">
-            <Typography variant="h6">
-                Plant stats
-            </Typography>
+        {!props.editModeEnabled &&
+            <Box
+                className="plant-detail-section">
+                <Typography variant="h6">
+                    Plant stats
+                </Typography>
 
-            <Box className="plant-detail-entry">
-                <Typography>
-                    Photos
-                </Typography>
-                <Typography>
-                    {props.imageIds.length}
-                </Typography>
+                <Box className="plant-detail-entry">
+                    <Typography>
+                        Photos
+                    </Typography>
+                    <Typography>
+                        {props.imageIds.length}
+                    </Typography>
+                </Box>
+                <Box className="plant-detail-entry">
+                    <Typography>
+                        Events
+                    </Typography>
+                    <Typography>
+                        {plantStats.events}
+                    </Typography>
+                </Box>
+                <Box className="plant-detail-entry">
+                    <Typography>
+                        Age (days)
+                    </Typography>
+                    <Typography>
+                        {
+                            props.plant?.startDate &&
+                            Math.floor(((new Date()).getTime() - new Date(props.plant?.startDate).getTime()) / (1000 * 3600 * 24))
+                            || "-"
+                        }
+                    </Typography>
+                </Box>
             </Box>
-            <Box className="plant-detail-entry">
-                <Typography>
-                    Events
-                </Typography>
-                <Typography>
-                    {plantStats.events}
-                </Typography>
-            </Box>
-            <Box className="plant-detail-entry">
-                <Typography>
-                    Age (days)
-                </Typography>
-                <Typography>
-                    {
-                        props.plant?.startDate &&
-                        Math.floor(((new Date()).getTime() - new Date(props.plant?.startDate).getTime()) / (1000 * 3600 * 24))
-                        || "-"
-                    }
-                </Typography>
-            </Box>
-        </Box>
+        }
 
-        <Box
-            className="plant-detail-section">
-            <Typography variant="h6">
-                Events stats
-            </Typography>
-            {
-                diaryEntryStats.length == 0 &&
-                <Typography sx={{ fontStyle: 'italic' }}>no event present</Typography>
-            }
-            {
-                diaryEntryStats.map((value: { type: string, date: Date; }) => {
-                    return <Box
-                        key={value.type}
-                        style={{
-                            display: "flex",
-                            alignItems: "baseline",
-                            gap: "5px",
-                            justifyContent: "space-between",
-                        }}>
-                        <Typography>
-                            Last {titleCase(value.type).toLowerCase()}
-                        </Typography>
-                        <Typography>
-                            {Math.floor(((new Date()).getTime() - new Date(value.date).getTime()) / (1000 * 3600 * 24))} days ago
-                        </Typography>
-                    </Box>;
-                })
-            }
-        </Box>
         {
-            props.imageIds.length > 0 &&
+            !props.editModeEnabled &&
+            <Box
+                className="plant-detail-section">
+                <Typography variant="h6">
+                    Events stats
+                </Typography>
+                {
+                    diaryEntryStats.length == 0 &&
+                    <Typography sx={{ fontStyle: 'italic' }}>no event present</Typography>
+                }
+                {
+                    diaryEntryStats.map((value: { type: string, date: Date; }) => {
+                        return <Box
+                            key={value.type}
+                            style={{
+                                display: "flex",
+                                alignItems: "baseline",
+                                gap: "5px",
+                                justifyContent: "space-between",
+                            }}>
+                            <Typography>
+                                Last {titleCase(value.type).toLowerCase()}
+                            </Typography>
+                            <Typography>
+                                {Math.floor(((new Date()).getTime() - new Date(value.date).getTime()) / (1000 * 3600 * 24))} days ago
+                            </Typography>
+                        </Box>;
+                    })
+                }
+            </Box>
+        }
+        {
+            !props.editModeEnabled && props.imageIds.length > 0 &&
             <Box className="plant-detail-entry">
                 <Typography variant="h6" sx={{ marginBottom: "10px", }}>
                     Gallery

--- a/frontend/src/components/SearchPage.tsx
+++ b/frontend/src/components/SearchPage.tsx
@@ -220,7 +220,7 @@ export default function SearchPage(props: {
                 refreshBotanicalInfosAndPlants={() => {
                     retrieveBotanicalInfos();
                     props.refreshPlants();
-                }}                
+                }}
             />
 
             <OutlinedInput

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -1,6 +1,7 @@
 export interface botanicalInfo {
     id: number,
     scientificName: string,
+    synonyms: string[],
     family: string,
     genus: string,
     species: string,

--- a/online-resources/documentation/content/installation/configurations.md
+++ b/online-resources/documentation/content/installation/configurations.md
@@ -30,6 +30,7 @@ There are 2 configuration files available:
     ALLOWED_ORIGINS=* # CORS allowed origins (comma separated list)
 
     LOG_LEVEL=DEBUG # could be: DEBUG, INFO, WARN, ERROR
+    UPDATE_EXISTING=false # update missing fields using Trefle service, useful on system version update if new fields are introduced
     ```
 * `frontend.env`: file containing the configuration for the frontend. An example of content is the following:
     ```properties


### PR DESCRIPTION
Hey Plant-it community!
I'm excited to share a new enhancement in this pull request. 🌱✨

## What's New?
I've introduced a "synonyms" field for user-created species. Now, you can easily search for a user-created species using any of its synonyms. This PR fixes #76.

## Why is it Important?
This enhancement improves the search functionality, making it more intuitive for users. No need to remember the exact scientific name, simply search with any synonym, and Plant-it will find the matching species.

## How to Use?
* Add a user-created species: when creating a new species, you can now include its synonyms.
* When "clone" a species from Trefle, the synonyms will be imported.
* Effortless Searching: Use any synonym to search for a species, and Plant-it will display the relevant user-created species.

Cheers and happy planting! 🌿🌼
