### PR TITLE
Move user stats to dedicated endpoint

### DIFF
--- a/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfoController.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfoController.java
@@ -65,10 +65,20 @@ public class BotanicalInfoController {
     }
 
 
-    @GetMapping("/{id}/_count")
-    @Operation(summary = "Count the botanical info.", description = "Count the botanical info.")
-    public ResponseEntity<Integer> count(@PathVariable Long id) {
-        return ResponseEntity.ok(botanicalInfoService.countPlants(id));
+    @GetMapping("/{botanicalInfoId}/_count")
+    @Operation(
+        summary = "Count the existing plant for a botanical info.",
+        description = "Count the existing plants with the botanical info which id is `botanicalInfoId`."
+    )
+    public ResponseEntity<Integer> count(@PathVariable Long botanicalInfoId) {
+        return ResponseEntity.ok(botanicalInfoService.countPlants(botanicalInfoId));
+    }
+
+
+    @GetMapping("/_count")
+    @Operation(summary = "Count the botanical info.", description = "Count all the botanical info.")
+    public ResponseEntity<Long> countAll() {
+        return ResponseEntity.ok(botanicalInfoService.count());
     }
 
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfoService.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/botanicalinfo/BotanicalInfoService.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -68,6 +69,12 @@ public class BotanicalInfoService {
                                       .stream().filter(
                 pl -> pl.getOwner().equals(authenticatedUserService.getAuthenticatedUser())).collect(Collectors.toSet())
                                       .size();
+    }
+
+    public long count() {
+        return plantRepository.findAllByOwner(authenticatedUserService.getAuthenticatedUser(), Pageable.unpaged())
+                              .getContent().stream().map(entity -> entity.getBotanicalInfo().getId())
+                              .collect(Collectors.toSet()).size();
     }
 
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantController.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantController.java
@@ -88,13 +88,6 @@ public class PlantController {
     }
 
 
-    @GetMapping("/_countBotanicalInfo")
-    @Operation(summary = "Count the botanical info", description = "Count the botanical info.")
-    public ResponseEntity<Long> countDistinctBotanicalInfo() {
-        return ResponseEntity.ok(plantService.getNumberOfDistinctBotanicalInfo());
-    }
-
-
     @GetMapping("/{plantName}/_name-exists")
     @Operation(summary = "Check if a plant name already exists.", description = "Check if a plant name already exists.")
     public ResponseEntity<Boolean> isNameAlreadyExisting(@PathVariable String plantName) {

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantService.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantService.java
@@ -1,7 +1,5 @@
 package com.github.mdeluise.plantit.plant;
 
-import java.util.stream.Collectors;
-
 import com.github.mdeluise.plantit.authentication.User;
 import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfo;
 import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfoService;
@@ -82,12 +80,6 @@ public class PlantService {
         }
         toSave.setBotanicalInfo(botanicalInfoService.get(toSave.getBotanicalInfo().getId()));
         return plantRepository.save(toSave);
-    }
-
-
-    public long getNumberOfDistinctBotanicalInfo() {
-        return getAll(Pageable.unpaged()).getContent().stream().map(entity -> entity.getBotanicalInfo().getId())
-                                         .collect(Collectors.toSet()).size();
     }
 
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/stats/StatsController.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/stats/StatsController.java
@@ -1,0 +1,31 @@
+package com.github.mdeluise.plantit.stats;
+
+import com.github.mdeluise.plantit.systeminfo.StatsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/stats")
+@Tag(name = "Stats", description = "Endpoints for user stats")
+public class StatsController {
+    private final StatsService statsService;
+
+
+    @Autowired
+    public StatsController(StatsService statsService) {
+        this.statsService = statsService;
+    }
+
+
+    @GetMapping
+    @Operation(summary = "Get the stats", description = "Get the authenticated user stats.")
+    public ResponseEntity<UserStats> getStats() {
+        final UserStats result = statsService.getStats();
+        return ResponseEntity.ok(result);
+    }
+}

--- a/backend/src/main/java/com/github/mdeluise/plantit/stats/UserStats.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/stats/UserStats.java
@@ -1,0 +1,48 @@
+package com.github.mdeluise.plantit.stats;
+
+public class UserStats {
+    private long diaryEntryCount;
+    private long plantCount;
+    private long botanicalInfoCount;
+    private long imageCount;
+
+
+    public long getDiaryEntryCount() {
+        return diaryEntryCount;
+    }
+
+
+    public void setDiaryEntryCount(long diaryEntryCount) {
+        this.diaryEntryCount = diaryEntryCount;
+    }
+
+
+    public long getPlantCount() {
+        return plantCount;
+    }
+
+
+    public void setPlantCount(long plantCount) {
+        this.plantCount = plantCount;
+    }
+
+
+    public long getBotanicalInfoCount() {
+        return botanicalInfoCount;
+    }
+
+
+    public void setBotanicalInfoCount(long botanicalInfoCount) {
+        this.botanicalInfoCount = botanicalInfoCount;
+    }
+
+
+    public long getImageCount() {
+        return imageCount;
+    }
+
+
+    public void setImageCount(long imageCount) {
+        this.imageCount = imageCount;
+    }
+}

--- a/backend/src/main/java/com/github/mdeluise/plantit/systeminfo/StatsService.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/systeminfo/StatsService.java
@@ -1,0 +1,37 @@
+package com.github.mdeluise.plantit.systeminfo;
+
+import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfoService;
+import com.github.mdeluise.plantit.diary.entry.DiaryEntryService;
+import com.github.mdeluise.plantit.image.storage.ImageStorageService;
+import com.github.mdeluise.plantit.plant.PlantService;
+import com.github.mdeluise.plantit.stats.UserStats;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StatsService {
+    private final PlantService plantService;
+    private final ImageStorageService imageStorageService;
+    private final DiaryEntryService diaryEntryService;
+    private final BotanicalInfoService botanicalInfoService;
+
+
+    @Autowired
+    public StatsService(PlantService plantService, ImageStorageService imageStorageService,
+                        DiaryEntryService diaryEntryService, BotanicalInfoService botanicalInfoService) {
+        this.plantService = plantService;
+        this.imageStorageService = imageStorageService;
+        this.diaryEntryService = diaryEntryService;
+        this.botanicalInfoService = botanicalInfoService;
+    }
+
+
+    public UserStats getStats() {
+        final UserStats result = new UserStats();
+        result.setImageCount(imageStorageService.count());
+        result.setDiaryEntryCount(diaryEntryService.count());
+        result.setPlantCount(plantService.count());
+        result.setBotanicalInfoCount(botanicalInfoService.count());
+        return result;
+    }
+}

--- a/backend/src/test/java/com/github/mdeluise/plantit/plant/controller/PlantControllerTest.java
+++ b/backend/src/test/java/com/github/mdeluise/plantit/plant/controller/PlantControllerTest.java
@@ -206,19 +206,6 @@ class PlantControllerTest {
 
 
     @Test
-    @DisplayName("Should count the plants' botanical info")
-    void shouldCountPlantBotanicalInfo() throws Exception {
-        final long count = 1;
-
-        Mockito.when(plantService.getNumberOfDistinctBotanicalInfo()).thenReturn(count);
-
-        mockMvc.perform(MockMvcRequestBuilders.get("/plant/_countBotanicalInfo"))
-               .andExpect(MockMvcResultMatchers.status().isOk())
-               .andExpect(MockMvcResultMatchers.jsonPath("$").value(count + ""));
-    }
-
-
-    @Test
     @DisplayName("Check if the plant's name already exists")
     void shouldCheckPlantNameExistence() throws Exception {
         final String plantName = "this is the plant name";

--- a/backend/src/test/java/com/github/mdeluise/plantit/plant/service/PlantServiceTest.java
+++ b/backend/src/test/java/com/github/mdeluise/plantit/plant/service/PlantServiceTest.java
@@ -153,35 +153,6 @@ class PlantServiceTest {
 
 
     @Test
-    @DisplayName("Should count distinct botanical info")
-    void shouldCountDistinctBotanicalInfo() {
-        final User authenticatedUser = new User();
-        authenticatedUser.setId(1L);
-        final Pageable pageable = Pageable.unpaged();
-        final int count = 3;
-        final Set<Plant> botanicalInfoPlants = new HashSet<>();
-        for (int i = 0; i < count; i++) {
-            final Plant plant = new Plant();
-            plant.setId((long) i);
-            plant.setOwner(authenticatedUser);
-            final BotanicalInfo botanicalInfo = new BotanicalInfo();
-            botanicalInfo.setId((long) i);
-            plant.setBotanicalInfo(botanicalInfo);
-            botanicalInfoPlants.add(plant);
-        }
-        final Plant notDistincBotanicalInfoPlant = new Plant();
-        notDistincBotanicalInfoPlant.setBotanicalInfo(botanicalInfoPlants.stream().toList().get(0).getBotanicalInfo());
-        botanicalInfoPlants.add(notDistincBotanicalInfoPlant);
-        final PageImpl<Plant> toReturn = new PageImpl<>(botanicalInfoPlants.stream().toList());
-
-        Mockito.when(authenticatedUserService.getAuthenticatedUser()).thenReturn(authenticatedUser);
-        Mockito.when(plantRepository.findAllByOwner(authenticatedUser, pageable)).thenReturn(toReturn);
-
-        Assertions.assertThat(plantService.getNumberOfDistinctBotanicalInfo()).as("count is correct").isEqualTo(count);
-    }
-
-
-    @Test
     @DisplayName("Should check if name already exists")
     void shouldCheckNameExistence() {
         final User authenticatedUser = new User();

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -11,6 +11,7 @@ import ArrowForwardIosSharpIcon from '@mui/icons-material/ArrowForwardIosSharp';
 import "../style/Settings.scss";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
+import { userStats } from "../interfaces";
 
 function UsernameDialog(props: {
     open: boolean,
@@ -276,40 +277,19 @@ function Stats(props: {
     printError: (err: any) => void;
 }) {
     const [expanded, setExpanded] = useState<boolean>(true);
-    const [totalEvents, setTotalEvents] = useState<number>(0);
-    const [totalPlants, setTotalPlants] = useState<number>(0);
-    const [totalBotanicalInfo, setTotalBotanicalInfo] = useState<number>(0);
-    const [totalPhotos, setTotalPhotos] = useState<number>(0);
+    const [stats, setStats] = useState<userStats>();
     const [erorr, setError] = useState<boolean>(false);
 
     useEffect(() => {
-        if (props.visibility && !erorr) {
-            props.requestor.get("diary/entry/_count")
-                .then(res => setTotalEvents(res.data))
-                .catch(err => {
-                    setError(true);
-                    props.printError(err);
-                });
-            props.requestor.get("plant/_count")
-                .then(res => setTotalPlants(res.data))
-                .catch(err => {
-                    setError(true);
-                    props.printError(err);
-                });
-            props.requestor.get("plant/_countBotanicalInfo")
-                .then(res => setTotalBotanicalInfo(res.data))
-                .catch(err => {
-                    setError(true);
-                    props.printError(err);
-                });
-            props.requestor.get("image/entity/_count")
-                .then(res => setTotalPhotos(res.data))
+        if (props.visibility) {
+            props.requestor.get("stats")
+                .then(res => setStats(res.data))
                 .catch(err => {
                     setError(true);
                     props.printError(err);
                 });
         }
-    });
+    }, [props.visibility]);
 
     return (
         <Accordion
@@ -364,19 +344,19 @@ function Stats(props: {
             >
                 <StatsSection
                     title="Events"
-                    value={totalEvents}
+                    value={stats?.diaryEntryCount || 0}
                 />
                 <StatsSection
                     title="Plants"
-                    value={totalPlants}
+                    value={stats?.plantCount || 0}
                 />
                 <StatsSection
                     title="Species"
-                    value={totalBotanicalInfo}
+                    value={stats?.botanicalInfoCount || 0}
                 />
                 <StatsSection
                     title="Photos"
-                    value={totalPhotos}
+                    value={stats?.imageCount || 0}
                 />
                 {/* <Box sx={{ width: "45%" }} /> */}
             </AccordionDetails>

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -52,3 +52,10 @@ export interface systemVersionInfo {
     isLatest: boolean,
     latestReleaseNote: string,
 }
+
+export interface userStats {
+    diaryEntryCount: number,
+    plantCount: number,
+    botanicalInfoCount: number,
+    imageCount: number,
+}


### PR DESCRIPTION
Hey Plant-it community!

## What's New?
In this update, I've consolidated user statistics into a dedicated endpoint. Previously spread across multiple endpoints, user stats are now conveniently accessible in one centralized location.

## Why is it Important?
By streamlining the user stats into a single endpoint, I aim to simplify access and provide a more cohesive experience. This change enhances the efficiency of retrieving user-related data, making it easier for you to gather the insights you need.

## How to Use?
To access user statistics, simply make a request to the new dedicated endpoint `GET /stats`. The response will contain comprehensive user stats, making it more straightforward to integrate this data into your Plant-it experience.

Cheers and happy planting! 🌿🌼