### PR TITLE
Fix image sorting issue

### DIFF
--- a/backend/src/main/java/com/github/mdeluise/plantit/image/PlantImageRepository.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/image/PlantImageRepository.java
@@ -11,8 +11,8 @@ public interface PlantImageRepository extends JpaRepository<PlantImage, String> 
     // Bugged due to the inheritance
     //List<PlantImage> findAllByPlantImageTarget(Plant target);
 
-    @Query("SELECT i.id from PlantImage i where i.target = ?1")
-    List<String> findAllIdsPlantByImageTarget(Plant target);
+    @Query("SELECT i.id FROM PlantImage i WHERE i.target = ?1 ORDER BY i.savedAt DESC")
+    List<String> findAllIdsPlantByImageTargetOrderBySavedAtDesc(Plant target);
 
     Integer countByTargetOwner(User user);
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/image/storage/FileSystemImageStorageService.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/image/storage/FileSystemImageStorageService.java
@@ -282,7 +282,7 @@ public class FileSystemImageStorageService implements ImageStorageService {
 
     @Override
     public Collection<String> getAllIds(ImageTarget linkedEntity) {
-        return plantImageRepository.findAllIdsPlantByImageTarget((Plant) linkedEntity);
+        return plantImageRepository.findAllIdsPlantByImageTargetOrderBySavedAtDesc((Plant) linkedEntity);
     }
 
 

--- a/backend/src/test/java/com/github/mdeluise/plantit/image/storage/service/FileSystemImageStorageServiceTest.java
+++ b/backend/src/test/java/com/github/mdeluise/plantit/image/storage/service/FileSystemImageStorageServiceTest.java
@@ -388,7 +388,7 @@ class FileSystemImageStorageServiceTest {
         target.setId(1L);
         final List<String> wanted = List.of("1", "2", "3");
 
-        Mockito.when(plantImageRepository.findAllIdsPlantByImageTarget(target)).thenReturn(wanted);
+        Mockito.when(plantImageRepository.findAllIdsPlantByImageTargetOrderBySavedAtDesc(target)).thenReturn(wanted);
 
         Assertions.assertThat(fileSystemImageStorageService.getAllIds(target)).as("all ids are correct")
                   .hasSameElementsAs(wanted);

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -54,6 +54,7 @@ this.addEventListener("fetch", event => {
     } else {
         const requestUrl = new URL(event.request.url);
 
+        if (event.request.method === 'GET') {
         // Cache images from any URL
         if (requestUrl.pathname.match(/\.(jpe?g|png|gif|bmp|svg)$/i)) {
             return fetch(event.request)
@@ -117,6 +118,7 @@ this.addEventListener("fetch", event => {
                     console.error("Error fetching backend response:", error);
                 });
         }
+    }
 
         // Default behavior if not matched
         return fetch(event.request);

--- a/frontend/src/components/PlantDetails.tsx
+++ b/frontend/src/components/PlantDetails.tsx
@@ -530,7 +530,7 @@ function PlantInfo(props: {
             setAutoCompleteOptions([props.botanicalInfo]);
         }
         props.requestor.get(`/image/entity/all/${props.plant?.id}`)
-            .then(res => props.setImageIds(res.data.reverse()))
+            .then(res => props.setImageIds(res.data))
             .catch(props.printError);
         setUseDate(props.plant.startDate !== undefined && props.plant.startDate !== null);
         setSelectedAvatarMode(props.plant.avatarMode || "NONE");


### PR DESCRIPTION
Hi Plant-it Community!

## What's new?
This PR addresses an issue with image sorting. Now, the images are correctly sorted from the most recent to the oldest, ensuring a better user experience when browsing through images.

## Why is it important?
The correct sorting of images is crucial for users to easily access and navigate through the content. This fix ensures that the images are displayed in the intended order, improving the overall usability of the application.

Cheers and happy planting! 🌿🌼
