### PR TITLE
Fix creation date for uploaded images

### DIFF
--- a/backend/src/main/java/com/github/mdeluise/plantit/image/EntityImage.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/image/EntityImage.java
@@ -1,5 +1,7 @@
 package com.github.mdeluise.plantit.image;
 
+import java.util.Date;
+
 public interface EntityImage {
     String getId();
 
@@ -12,4 +14,8 @@ public interface EntityImage {
     void setUrl(String url);
 
     String getUrl();
+
+    void setCreateOn(Date createOn);
+
+    Date getCreateOn();
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/image/EntityImageImpl.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/image/EntityImageImpl.java
@@ -1,5 +1,9 @@
 package com.github.mdeluise.plantit.image;
 
+import java.io.Serializable;
+import java.util.Date;
+import java.util.UUID;
+
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.DiscriminatorType;
 import jakarta.persistence.Entity;
@@ -9,10 +13,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
-
-import java.io.Serializable;
-import java.util.Date;
-import java.util.UUID;
 
 @Entity(name = "entity_images")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
@@ -26,7 +26,7 @@ public class EntityImageImpl implements EntityImage, Serializable {
     @Length(max = 100)
     private String description;
     @NotNull
-    private Date savedAt = new Date();
+    private Date createOn;
     @NotBlank
     @Length(max = 255)
     private String url;
@@ -62,16 +62,6 @@ public class EntityImageImpl implements EntityImage, Serializable {
     }
 
 
-    public Date getSavedAt() {
-        return savedAt;
-    }
-
-
-    public void setSavedAt(Date savedAt) {
-        this.savedAt = savedAt;
-    }
-
-
     @Override
     public String getPath() {
         return path;
@@ -93,5 +83,17 @@ public class EntityImageImpl implements EntityImage, Serializable {
     @Override
     public void setUrl(String url) {
         this.url = url;
+    }
+
+
+    @Override
+    public void setCreateOn(Date createOn) {
+        this.createOn = createOn;
+    }
+
+
+    @Override
+    public Date getCreateOn() {
+        return createOn;
     }
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/image/ImageController.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/image/ImageController.java
@@ -1,8 +1,11 @@
 package com.github.mdeluise.plantit.image;
 
 import java.net.MalformedURLException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Date;
 
 import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfo;
 import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfoService;
@@ -60,7 +63,7 @@ public class ImageController {
             botanicalInfoService.save(linkedEntity);
             imageStorageService.remove(toDelete.getId());
         }
-        final EntityImage saved = imageStorageService.save(file, linkedEntity, null);
+        final EntityImage saved = imageStorageService.save(file, linkedEntity, null, null);
         linkedEntity.setImage((BotanicalInfoImage) saved);
         botanicalInfoService.save(linkedEntity);
         return ResponseEntity.ok(imageDtoConverter.convertToDTO(saved));
@@ -132,9 +135,14 @@ public class ImageController {
     @PostMapping("/entity/{id}")
     public ResponseEntity<String> saveEntityImage(@RequestParam("image") MultipartFile file,
                                                   @PathVariable("id") Long entityId,
-                                                  @RequestBody(required = false) String description) {
+                                                  @RequestParam(value = "creationDate", required = false) String creationDateStr,
+                                                  @RequestParam(required = false) String description)
+        throws ParseException {
         final Plant linkedEntity = plantService.get(entityId);
-        final EntityImage saved = imageStorageService.save(file, linkedEntity, description);
+        final Date creationDate = creationDateStr != null ?
+                                      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").parse(creationDateStr) :
+                                      null;
+        final EntityImage saved = imageStorageService.save(file, linkedEntity, creationDate, description);
         return ResponseEntity.ok(saved.getId());
     }
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/image/ImageDTO.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/image/ImageDTO.java
@@ -1,15 +1,15 @@
 package com.github.mdeluise.plantit.image;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.Date;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "Image", description = "Represents a plant's image.")
 public class ImageDTO {
     @Schema(description = "ID of the image.", accessMode = Schema.AccessMode.READ_ONLY)
     private String id;
-    @Schema(description = "Save date of the image.", accessMode = Schema.AccessMode.READ_ONLY)
-    private Date savedAt;
+    @Schema(description = "Creation date of the image.", accessMode = Schema.AccessMode.READ_ONLY)
+    private Date createOn;
     @Schema(description = "URL to retrieve the content of the image.", accessMode = Schema.AccessMode.READ_ONLY)
     private String url;
     @Schema(description = "Description of the image.", accessMode = Schema.AccessMode.READ_ONLY)
@@ -28,13 +28,13 @@ public class ImageDTO {
     }
 
 
-    public Date getSavedAt() {
-        return savedAt;
+    public Date getCreateOn() {
+        return createOn;
     }
 
 
-    public void setSavedAt(Date savedAt) {
-        this.savedAt = savedAt;
+    public void setCreateOn(Date createOn) {
+        this.createOn = createOn;
     }
 
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/image/PlantImageRepository.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/image/PlantImageRepository.java
@@ -11,7 +11,7 @@ public interface PlantImageRepository extends JpaRepository<PlantImage, String> 
     // Bugged due to the inheritance
     //List<PlantImage> findAllByPlantImageTarget(Plant target);
 
-    @Query("SELECT i.id FROM PlantImage i WHERE i.target = ?1 ORDER BY i.savedAt DESC")
+    @Query("SELECT i.id FROM PlantImage i WHERE i.target = ?1 ORDER BY i.createOn DESC")
     List<String> findAllIdsPlantByImageTargetOrderBySavedAtDesc(Plant target);
 
     Integer countByTargetOwner(User user);

--- a/backend/src/main/java/com/github/mdeluise/plantit/image/storage/FileSystemImageStorageService.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/image/storage/FileSystemImageStorageService.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Date;
 
 import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfo;
 import com.github.mdeluise.plantit.common.AuthenticatedUserService;
@@ -66,7 +67,7 @@ public class FileSystemImageStorageService implements ImageStorageService {
 
 
     @Override
-    public EntityImage save(MultipartFile file, ImageTarget linkedEntity, String description) {
+    public EntityImage save(MultipartFile file, ImageTarget linkedEntity, Date creationDate, String description) {
         if (file.isEmpty()) {
             logger.error("File is empty");
             throw new StorageException("Failed to save empty file.");
@@ -95,6 +96,11 @@ public class FileSystemImageStorageService implements ImageStorageService {
                     ((PlantImage) entityImage).setTarget(p);
                 } else {
                     throw new UnsupportedOperationException("Could not find suitable class for linkedEntity");
+                }
+                if (creationDate != null) {
+                    entityImage.setCreateOn(creationDate);
+                } else {
+                    entityImage.setCreateOn(new Date());
                 }
                 final String fileName = String.format("%s/%s.%s", rootLocation, entityImage.getId(), fileExtension);
                 final Path pathToFile = Path.of(fileName);

--- a/backend/src/main/java/com/github/mdeluise/plantit/image/storage/ImageStorageService.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/image/storage/ImageStorageService.java
@@ -2,6 +2,7 @@ package com.github.mdeluise.plantit.image.storage;
 
 import java.net.MalformedURLException;
 import java.util.Collection;
+import java.util.Date;
 
 import com.github.mdeluise.plantit.image.EntityImage;
 import com.github.mdeluise.plantit.image.ImageTarget;
@@ -10,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ImageStorageService {
     void init();
 
-    EntityImage save(MultipartFile file, ImageTarget linkedEntity, String description);
+    EntityImage save(MultipartFile file, ImageTarget linkedEntity, Date creationDate, String description);
 
     EntityImage save(String url, ImageTarget linkedEntity) throws MalformedURLException;
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantAvatarGetter.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantAvatarGetter.java
@@ -25,7 +25,7 @@ public class PlantAvatarGetter {
         final List<PlantImage> plantImages = imageStorageService.getAllIds(plant).stream()
                                                                 .map(imageStorageService::get)
                                                                 .map(x -> (PlantImage) x)
-                                                                .sorted(Comparator.comparing(EntityImageImpl::getSavedAt))
+                                                                .sorted(Comparator.comparing(EntityImageImpl::getCreateOn))
                                                                 .toList();
         return switch (plant.getAvatarMode()) {
             case SPECIFIED -> plant.getAvatarImage();

--- a/backend/src/main/resources/dblogs/changelog/changes/v0-0-0.xml
+++ b/backend/src/main/resources/dblogs/changelog/changes/v0-0-0.xml
@@ -188,7 +188,7 @@
             </column>
             <column name="description" type="varchar(100)">
             </column>
-            <column name="saved_at" type="datetime">
+            <column name="create_on" type="datetime">
                 <constraints nullable="false"/>
             </column>
             <column name="url" type="varchar(255)">
@@ -339,6 +339,18 @@
                 <constraints nullable="true"/>
             </column>
         </addColumn>
+    </changeSet>
+
+
+    <!-- can be removed after update to v0.3.0 -->
+    <changeSet id="updateTo0.3.0" author="MDeLuise">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="entity_images" columnName="create_on"/>
+            </not>
+        </preConditions>
+        <renameColumn tableName="entity_images" oldColumnName="saved_at"
+                      newColumnName="create_on" columnDataType="datetime"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/backend/src/main/resources/dblogs/changelog/init-dummy-data.xml
+++ b/backend/src/main/resources/dblogs/changelog/init-dummy-data.xml
@@ -126,21 +126,21 @@
         <insert tableName="entity_images">
             <column name="id" value="6a204453-175f-426f-8111-dabf3489d3e1"/>
             <column name="image_type" value="1"/>
-            <column name="saved_at" value="${now}"/>
+            <column name="create_on" value="${now}"/>
             <column name="url" value="https://bs.plantnet.org/image/o/b649fffd28d057200573eefeeafb01f9a82c9a8c"/>
             <column name="botanical_info_entity_id" value="99"/>
         </insert>
         <insert tableName="entity_images">
             <column name="id" value="72028063-00ba-4a63-88f3-412b69d66650"/>
             <column name="image_type" value="1"/>
-            <column name="saved_at" value="${now}"/>
+            <column name="create_on" value="${now}"/>
             <column name="url" value="https://bs.plantnet.org/image/o/ec1bdc007ab8b716b2e1cfc41404e561949e09d2"/>
             <column name="botanical_info_entity_id" value="98"/>
         </insert>
         <insert tableName="entity_images">
             <column name="id" value="3531aae7-486f-4650-a4e3-047d3755a759"/>
             <column name="image_type" value="1"/>
-            <column name="saved_at" value="${now}"/>
+            <column name="create_on" value="${now}"/>
             <column name="url" value="/3531aae7-486f-4650-a4e3-047d3755a759"/>
             <column name="path" value="/tmp/plant-it/dummy-image.jpg"/>
             <column name="botanical_info_entity_id" value="97"/>

--- a/backend/src/test/java/com/github/mdeluise/plantit/image/storage/service/FileSystemImageStorageServiceTest.java
+++ b/backend/src/test/java/com/github/mdeluise/plantit/image/storage/service/FileSystemImageStorageServiceTest.java
@@ -73,7 +73,7 @@ class FileSystemImageStorageServiceTest {
         final Plant imageTarget = new Plant();
         imageTarget.setId(imageTargetId);
 
-        fileSystemImageStorageService.save(toSave, imageTarget, "description");
+        fileSystemImageStorageService.save(toSave, imageTarget, null, "description");
 
         Assertions.assertThat(tmpDir.toFile().listFiles().length).as("number of file is correct").isEqualTo(1);
         ArgumentCaptor<PlantImage> argument = ArgumentCaptor.forClass(PlantImage.class);
@@ -91,7 +91,7 @@ class FileSystemImageStorageServiceTest {
         final BotanicalInfo imageTarget = new BotanicalInfo();
         imageTarget.setId(imageTargetId);
 
-        fileSystemImageStorageService.save(toSave, imageTarget, "description");
+        fileSystemImageStorageService.save(toSave, imageTarget, null, "description");
 
         Assertions.assertThat(tmpDir.toFile().listFiles().length).as("number of file is correct").isEqualTo(1);
         ArgumentCaptor<BotanicalInfoImage> argument = ArgumentCaptor.forClass(BotanicalInfoImage.class);

--- a/frontend/src/components/PlantDetails.tsx
+++ b/frontend/src/components/PlantDetails.tsx
@@ -69,7 +69,7 @@ function PlantImageFullSize(props: {
             .then(res => {
                 setImageMetadata({
                     description: res.data.description,
-                    createOn: res.data.savedAt,
+                    createOn: res.data.createOn,
                 })
             })
             .catch(props.printError);
@@ -690,7 +690,7 @@ function PlantInfo(props: {
                     Species info
                 </Typography>
                 <Box className="plant-detail-entry" sx={{ flexDirection: "column" }}>
-                    <Box sx={{display: "flex", width: "100%", justifyContent: "space-between", alignItems: "center"}}>
+                    <Box sx={{ display: "flex", width: "100%", justifyContent: "space-between", alignItems: "center" }}>
                         <Typography>
                             Synonyms
                         </Typography>
@@ -1086,15 +1086,17 @@ function BottomBar(props: {
             .catch(props.printError);
     };
 
-    const addEntityImage = (toUpload: File): void => {
+    const addEntityImage = (toUpload: File, creationDate?: Date, description?: string): void => {
         let formData = new FormData();
         formData.append('image', toUpload);
+        formData.append('creationDate', creationDate ? creationDate.toISOString() : ''); // Append creationDate to formData
+        formData.append('description', description || ''); // Append description to formData
         props.requestor.post(`/image/entity/${props.plant?.id}`, formData)
             .then(res => {
                 props.addUploadedImgs(res.data);
             })
             .catch(props.printError);
-    };
+    };    
 
     return <Box
         sx={{
@@ -1173,7 +1175,7 @@ function BottomBar(props: {
                         hidden
                         onChange={event => {
                             if (event.target.files != undefined) {
-                                addEntityImage(event.target.files[0]);
+                                addEntityImage(event.target.files[0], new Date(event.target.files[0].lastModified));
                             }
                         }}
                     />


### PR DESCRIPTION
Hey Plant-it community!
<br/>
I've made some updates to address the issue regarding the incorrect creation date for uploaded images.
## What's new?
Now, the creation date of uploaded images reflects the actual creation date rather than the upload date.
## Why is it important?
This change ensures that the creation date of images accurately represents when they were originally created, providing users with more precise data management.
## How to Use?
Simply upload images as usual, and the system will automatically set the creation date based on the original creation date of the image file.

<br/>
<br/>
Cheers and happy planting! 🌿🌼