### PR TITLE
Add new event types and plant info

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Plant-it helps you remember the last time you did a treatment of your plants, wh
 * View all the logged events, filtering by plant and event type
 * Upload photos of your plants
 * 🔜 Set reminder for some actions on your plants (e.g. notify if not watered every 4 days)
-* 🔜 Dark/Light mode
+
+Take a look at the [roadmap](https://github.com/users/MDeLuise/projects/3/views/1) for a more detailed list of future features and enhancements.
 
 ## Quickstart 
 Installing Plant-it is pretty straight forward, in order to do so follow these steps:
@@ -121,7 +122,7 @@ Feel free to contribute and help improve the repo.
 You can submit any of this in the [issues](https://github.com/MDeLuise/plant-it/issues/new/choose) section of the repository. Chose the right template and then fill the required info.
 
 ### Feature development
-Let's discuss first possible solutions for the development before start working on that, please open a [feature request issue](https://github.com/MDeLuise/plant-it/issues/new?assignees=&labels=&projects=&template=feature_request.yml).
+Let's discuss first possible solutions for the development before start working on that, please open a [feature request issue](https://github.com/MDeLuise/plant-it/issues/new?assignees=&labels=feature+request&projects=&template=feature_request.yml).
 
 ### How to contribute
 If you want to make some changes and test them locally <a href="https://docs.plant-it.org/support/local-environment/">take a look at the documentation</a>.

--- a/backend/src/main/java/com/github/mdeluise/plantit/diary/entry/DiaryEntryDTO.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/diary/entry/DiaryEntryDTO.java
@@ -1,8 +1,9 @@
 package com.github.mdeluise.plantit.diary.entry;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "Diary entry", description = "Represents an entry in the diary.")
 public class DiaryEntryDTO {
@@ -18,8 +19,9 @@ public class DiaryEntryDTO {
     private Long diaryId;
     @Schema(description = "ID of the tracked entity.", accessMode = Schema.AccessMode.READ_ONLY)
     private Long diaryTargetId;
+    @JsonProperty("diaryTargetPersonalName")
     @Schema(description = "Personal name of the tracked entity.", accessMode = Schema.AccessMode.READ_ONLY)
-    private String diaryTargetPersonalName;
+    private String diaryTargetInfoPersonalName;
 
 
     public Long getId() {
@@ -82,12 +84,12 @@ public class DiaryEntryDTO {
     }
 
 
-    public void setDiaryTargetPersonalName(String diaryTargetPersonalName) {
-        this.diaryTargetPersonalName = diaryTargetPersonalName;
+    public void setDiaryTargetInfoPersonalName(String diaryTargetInfoPersonalName) {
+        this.diaryTargetInfoPersonalName = diaryTargetInfoPersonalName;
     }
 
 
-    public String getDiaryTargetPersonalName() {
-        return diaryTargetPersonalName;
+    public String getDiaryTargetInfoPersonalName() {
+        return diaryTargetInfoPersonalName;
     }
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/diary/entry/DiaryEntryType.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/diary/entry/DiaryEntryType.java
@@ -10,4 +10,7 @@ public enum DiaryEntryType {
     WATER_CHANGING,
     OBSERVATION,
     TREATMENT,
+    PROPAGATING,
+    PRUNING,
+    REPOTTING,
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/Plant.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/Plant.java
@@ -1,7 +1,6 @@
 package com.github.mdeluise.plantit.plant;
 
 import java.io.Serializable;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -11,7 +10,9 @@ import com.github.mdeluise.plantit.botanicalinfo.BotanicalInfo;
 import com.github.mdeluise.plantit.diary.Diary;
 import com.github.mdeluise.plantit.image.ImageTarget;
 import com.github.mdeluise.plantit.image.PlantImage;
+import com.github.mdeluise.plantit.plant.info.PlantInfo;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -23,9 +24,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.hibernate.validator.constraints.Length;
 
 @Entity
 @Table(name = "plants")
@@ -33,15 +32,8 @@ public class Plant implements Serializable, ImageTarget {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
-    private Date startDate;
-    @NotBlank
-    @Length(max = 30)
-    private String personalName;
-    private Date endDate;
-    @Enumerated(EnumType.STRING)
-    private PlantState plantState;
-    @Length(max = 8500)
-    private String note;
+    @Embedded
+    private PlantInfo info;
     @OneToOne(mappedBy = "target", cascade = CascadeType.ALL)
     private Diary diary;
     @NotNull
@@ -62,7 +54,7 @@ public class Plant implements Serializable, ImageTarget {
 
 
     public Plant() {
-        this.plantState = PlantState.PURCHASED;
+        this.info = new PlantInfo();
     }
 
 
@@ -79,56 +71,6 @@ public class Plant implements Serializable, ImageTarget {
 
     public void setId(Long id) {
         this.id = id;
-    }
-
-
-    public Date getStartDate() {
-        return startDate;
-    }
-
-
-    public void setStartDate(Date startDate) {
-        this.startDate = startDate;
-    }
-
-
-    public String getPersonalName() {
-        return personalName;
-    }
-
-
-    public void setPersonalName(String personalName) {
-        this.personalName = personalName;
-    }
-
-
-    public Date getEndDate() {
-        return endDate;
-    }
-
-
-    public void setEndDate(Date endDate) {
-        this.endDate = endDate;
-    }
-
-
-    public PlantState getState() {
-        return plantState;
-    }
-
-
-    public void setState(PlantState plantState) {
-        this.plantState = plantState;
-    }
-
-
-    public String getNote() {
-        return note;
-    }
-
-
-    public void setNote(String note) {
-        this.note = note;
     }
 
 
@@ -195,6 +137,16 @@ public class Plant implements Serializable, ImageTarget {
     }
 
 
+    public PlantInfo getInfo() {
+        return info;
+    }
+
+
+    public void setInfo(PlantInfo plantInfo) {
+        this.info = plantInfo;
+    }
+
+
     @SuppressWarnings("BooleanExpressionComplexity") //FIXME
     @Override
     public boolean equals(Object o) {
@@ -205,9 +157,7 @@ public class Plant implements Serializable, ImageTarget {
             return false;
         }
         final Plant plant = (Plant) o;
-        return Objects.equals(id, plant.id) && Objects.equals(startDate, plant.startDate) &&
-                   Objects.equals(personalName, plant.personalName) && Objects.equals(endDate, plant.endDate) &&
-                   plantState == plant.plantState && Objects.equals(note, plant.note) &&
+        return Objects.equals(id, plant.id) && Objects.equals(info, plant.info) &&
                    Objects.equals(diary, plant.diary) && Objects.equals(owner, plant.owner) &&
                    Objects.equals(botanicalInfo, plant.botanicalInfo) && avatarMode == plant.avatarMode &&
                    Objects.equals(avatarImage, plant.avatarImage);
@@ -216,8 +166,6 @@ public class Plant implements Serializable, ImageTarget {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, startDate, personalName, endDate, plantState, note, diary, owner, botanicalInfo,
-                            avatarMode, avatarImage
-        );
+        return Objects.hash(id, info, diary, owner, botanicalInfo, avatarMode, avatarImage);
     }
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantDTO.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantDTO.java
@@ -1,23 +1,16 @@
 package com.github.mdeluise.plantit.plant;
 
-import java.util.Date;
 import java.util.Objects;
 
+import com.github.mdeluise.plantit.plant.info.PlantInfoDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "Plant", description = "Represents a plant.")
 public class PlantDTO {
     @Schema(description = "ID of the plant.", accessMode = Schema.AccessMode.READ_ONLY)
     private Long id;
-    @Schema(description = "Start date plant.")
-    private Date startDate;
-    @Schema(description = "Personal name of the plant.")
-    private String personalName;
-    @Schema(description = "End date of the plant.")
-    private Date endDate;
-    @Schema(description = "PlantState of the plant.")
-    private PlantState plantState;
-    @Schema(description = "Note of the plant.")
-    private String note;
+    @Schema(description = "Info about the plant.")
+    private PlantInfoDTO info;
     @Schema(description = "Owner ID of the plant.", accessMode = Schema.AccessMode.READ_ONLY)
     private Long ownerId;
     @Schema(description = "ID of the plant's avatar.")
@@ -33,6 +26,7 @@ public class PlantDTO {
 
 
     public PlantDTO() {
+        this.info = new PlantInfoDTO();
     }
 
 
@@ -46,53 +40,13 @@ public class PlantDTO {
     }
 
 
-    public Date getStartDate() {
-        return startDate;
+    public PlantInfoDTO getInfo() {
+        return info;
     }
 
 
-    public void setStartDate(Date startDate) {
-        this.startDate = startDate;
-    }
-
-
-    public String getPersonalName() {
-        return personalName;
-    }
-
-
-    public void setPersonalName(String personalName) {
-        this.personalName = personalName;
-    }
-
-
-    public Date getEndDate() {
-        return endDate;
-    }
-
-
-    public void setEndDate(Date endDate) {
-        this.endDate = endDate;
-    }
-
-
-    public PlantState getState() {
-        return plantState;
-    }
-
-
-    public void setState(PlantState plantState) {
-        this.plantState = plantState;
-    }
-
-
-    public String getNote() {
-        return note;
-    }
-
-
-    public void setNote(String note) {
-        this.note = note;
+    public void setInfo(PlantInfoDTO plantInfoDTO) {
+        this.info = plantInfoDTO;
     }
 
 
@@ -165,9 +119,7 @@ public class PlantDTO {
             return false;
         }
         final PlantDTO plantDTO = (PlantDTO) o;
-        return Objects.equals(id, plantDTO.id) && Objects.equals(startDate, plantDTO.startDate) &&
-                   Objects.equals(personalName, plantDTO.personalName) && Objects.equals(endDate, plantDTO.endDate) &&
-                   plantState == plantDTO.plantState && Objects.equals(note, plantDTO.note) &&
+        return Objects.equals(id, plantDTO.id) && Objects.equals(info, plantDTO.info) &&
                    Objects.equals(ownerId, plantDTO.ownerId) && Objects.equals(avatarImageId, plantDTO.avatarImageId) &&
                    Objects.equals(avatarImageUrl, plantDTO.avatarImageUrl) &&
                    Objects.equals(avatarMode, plantDTO.avatarMode) && Objects.equals(diaryId, plantDTO.diaryId) &&
@@ -177,8 +129,7 @@ public class PlantDTO {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, startDate, personalName, endDate, plantState, note, ownerId, avatarImageId,
-                            avatarImageUrl, avatarMode, diaryId, botanicalInfoId
-        );
+        return Objects.hash(
+            id, info, ownerId, avatarImageId, avatarImageUrl, avatarMode, diaryId, botanicalInfoId);
     }
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantDTOConverter.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantDTOConverter.java
@@ -2,6 +2,9 @@ package com.github.mdeluise.plantit.plant;
 
 import com.github.mdeluise.plantit.common.AbstractDTOConverter;
 import com.github.mdeluise.plantit.image.EntityImage;
+import com.github.mdeluise.plantit.plant.info.PlantInfo;
+import com.github.mdeluise.plantit.plant.info.PlantInfoDTO;
+import com.github.mdeluise.plantit.plant.info.PlantInfoDTOConverter;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -9,24 +12,32 @@ import org.springframework.stereotype.Component;
 @Component
 public class PlantDTOConverter extends AbstractDTOConverter<Plant, PlantDTO> {
     private final PlantAvatarGetter plantAvatarGetter;
+    private final PlantInfoDTOConverter plantInfoDtoConverter;
 
 
     @Autowired
-    public PlantDTOConverter(ModelMapper modelMapper, PlantAvatarGetter plantAvatarGetter) {
+    public PlantDTOConverter(ModelMapper modelMapper, PlantAvatarGetter plantAvatarGetter,
+                             PlantInfoDTOConverter plantInfoDtoConverter) {
         super(modelMapper);
         this.plantAvatarGetter = plantAvatarGetter;
+        this.plantInfoDtoConverter = plantInfoDtoConverter;
     }
 
 
     @Override
     public Plant convertFromDTO(PlantDTO dto) {
-        return modelMapper.map(dto, Plant.class);
+        final Plant result = modelMapper.map(dto, Plant.class);
+        final PlantInfo plantInfo = plantInfoDtoConverter.convertFromDTO(dto.getInfo());
+        result.setInfo(plantInfo);
+        return result;
     }
 
 
     @Override
     public PlantDTO convertToDTO(Plant data) {
         final PlantDTO result = modelMapper.map(data, PlantDTO.class);
+        final PlantInfoDTO plantInfoDTO = plantInfoDtoConverter.convertToDTO(data.getInfo());
+        result.setInfo(plantInfoDTO);
         final EntityImage plantAvatar = plantAvatarGetter.getPlantAvatar(data);
         if (plantAvatar != null) {
             result.setAvatarImageId(plantAvatarGetter.getPlantAvatar(data).getId());

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantRepository.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantRepository.java
@@ -8,9 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PlantRepository extends JpaRepository<Plant, Long> {
     Page<Plant> findAllByOwner(User user, Pageable pageable);
 
-    Page<Plant> findAllByOwnerAndState(User user, PlantState plantState, Pageable pageable);
-
     Long countByOwner(User user);
 
-    boolean existsByOwnerAndPersonalName(User user, String personalName);
+    boolean existsByOwnerAndInfoPersonalName(User user, String personalName);
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantService.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/PlantService.java
@@ -84,7 +84,7 @@ public class PlantService {
 
 
     public boolean isNameAlreadyExisting(String plantName) {
-        return plantRepository.existsByOwnerAndPersonalName(authenticatedUserService.getAuthenticatedUser(), plantName);
+        return plantRepository.existsByOwnerAndInfoPersonalName(authenticatedUserService.getAuthenticatedUser(), plantName);
     }
 
 
@@ -115,12 +115,8 @@ public class PlantService {
             throw new UnauthorizedException();
         }
         final BotanicalInfo newBotanicalInfo = botanicalInfoService.get(updated.getBotanicalInfo().getId());
-        toUpdate.setPersonalName(updated.getPersonalName());
         toUpdate.setBotanicalInfo(newBotanicalInfo);
-        toUpdate.setState(updated.getState());
-        toUpdate.setNote(updated.getNote());
-        toUpdate.setStartDate(updated.getStartDate());
-        toUpdate.setEndDate(updated.getEndDate());
+        toUpdate.setInfo(updated.getInfo());
 
         handleAvatar(updated, toUpdate);
 

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/info/PlantInfo.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/info/PlantInfo.java
@@ -1,0 +1,148 @@
+package com.github.mdeluise.plantit.plant.info;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+
+import com.github.mdeluise.plantit.plant.PlantState;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
+
+@Embeddable
+public class PlantInfo implements Serializable {
+    private Date startDate;
+    @NotBlank
+    @Length(max = 30)
+    private String personalName;
+    private Date endDate;
+    @Enumerated(EnumType.STRING)
+    private PlantState plantState;
+    @Length(max = 8500)
+    private String note;
+    private Double purchasedPrice;
+    @Length(max = 4)
+    private String currencySymbol;
+    @Length(max = 100)
+    private String seller;
+    @Length(max = 100)
+    private String location;
+
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+
+    public void setStartDate(Date startDate) {
+        this.startDate = startDate;
+    }
+
+
+    public String getPersonalName() {
+        return personalName;
+    }
+
+
+    public void setPersonalName(String personalName) {
+        this.personalName = personalName;
+    }
+
+
+    public Date getEndDate() {
+        return endDate;
+    }
+
+
+    public void setEndDate(Date endDate) {
+        this.endDate = endDate;
+    }
+
+
+    public PlantState getPlantState() {
+        return plantState;
+    }
+
+
+    public void setPlantState(PlantState plantState) {
+        this.plantState = plantState;
+    }
+
+
+    public String getNote() {
+        return note;
+    }
+
+
+    public void setNote(String note) {
+        this.note = note;
+    }
+
+
+    public Double getPurchasedPrice() {
+        return purchasedPrice;
+    }
+
+
+    public void setPurchasedPrice(Double purchasedPrice) {
+        this.purchasedPrice = purchasedPrice;
+    }
+
+
+    public String getSeller() {
+        return seller;
+    }
+
+
+    public void setSeller(String seller) {
+        this.seller = seller;
+    }
+
+
+    public String getLocation() {
+        return location;
+    }
+
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+
+    public String getCurrencySymbol() {
+        return currencySymbol;
+    }
+
+
+    public void setCurrencySymbol(String currencySymbol) {
+        this.currencySymbol = currencySymbol;
+    }
+
+
+    @SuppressWarnings("BooleanExpressionComplexity") //FIXME
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final PlantInfo plantInfo = (PlantInfo) o;
+        return Objects.equals(startDate, plantInfo.startDate) && Objects.equals(personalName, plantInfo.personalName) &&
+                   Objects.equals(endDate, plantInfo.endDate) && plantState == plantInfo.plantState &&
+                   Objects.equals(note, plantInfo.note) && Objects.equals(purchasedPrice, plantInfo.purchasedPrice) &&
+                   Objects.equals(currencySymbol, plantInfo.currencySymbol) &&
+                   Objects.equals(seller, plantInfo.seller) && Objects.equals(location, plantInfo.location);
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(startDate, personalName, endDate, plantState, note, purchasedPrice, currencySymbol, seller,
+                            location
+        );
+    }
+}

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/info/PlantInfoDTO.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/info/PlantInfoDTO.java
@@ -1,0 +1,145 @@
+package com.github.mdeluise.plantit.plant.info;
+
+import java.util.Date;
+import java.util.Objects;
+
+import com.github.mdeluise.plantit.plant.PlantState;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "Plant info", description = "Represents additional info about a plant.")
+public class PlantInfoDTO {
+    @Schema(description = "Purchased date of the plant.")
+    private Date startDate;
+    @Schema(description = "Personal name of the plant.")
+    private String personalName;
+    @Schema(description = "End date of the plant.")
+    private Date endDate;
+    @Schema(description = "State of the plant.")
+    private PlantState plantState;
+    @Schema(description = "Note of the plant.")
+    private String note;
+    @Schema(description = "Price of the plant when purchased.")
+    private Double purchasedPrice;
+    @Schema(description = "Currency of the purchased price.")
+    private String currencySymbol;
+    @Schema(description = "Seller of the plant.")
+    private String seller;
+    @Schema(description = "Physical location of the plant.")
+    private String location;
+
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+
+    public void setStartDate(Date startDate) {
+        this.startDate = startDate;
+    }
+
+
+    public String getPersonalName() {
+        return personalName;
+    }
+
+
+    public void setPersonalName(String personalName) {
+        this.personalName = personalName;
+    }
+
+
+    public Date getEndDate() {
+        return endDate;
+    }
+
+
+    public void setEndDate(Date endDate) {
+        this.endDate = endDate;
+    }
+
+
+    public PlantState getPlantState() {
+        return plantState;
+    }
+
+
+    public void setPlantState(PlantState plantState) {
+        this.plantState = plantState;
+    }
+
+
+    public String getNote() {
+        return note;
+    }
+
+
+    public void setNote(String note) {
+        this.note = note;
+    }
+
+
+    public Double getPurchasedPrice() {
+        return purchasedPrice;
+    }
+
+
+    public void setPurchasedPrice(Double purchasedPrice) {
+        this.purchasedPrice = purchasedPrice;
+    }
+
+
+    public String getCurrencySymbol() {
+        return currencySymbol;
+    }
+
+
+    public void setCurrencySymbol(String currencySymbol) {
+        this.currencySymbol = currencySymbol;
+    }
+
+
+    public String getSeller() {
+        return seller;
+    }
+
+
+    public void setSeller(String seller) {
+        this.seller = seller;
+    }
+
+
+    public String getLocation() {
+        return location;
+    }
+
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+
+    @SuppressWarnings("BooleanExpressionComplexity") //FIXME
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final PlantInfoDTO that = (PlantInfoDTO) o;
+        return Objects.equals(startDate, that.startDate) && Objects.equals(personalName, that.personalName) &&
+                   Objects.equals(endDate, that.endDate) && plantState == that.plantState &&
+                   Objects.equals(note, that.note) && Objects.equals(purchasedPrice, that.purchasedPrice) &&
+                   Objects.equals(currencySymbol, that.currencySymbol) && Objects.equals(seller, that.seller) &&
+                   Objects.equals(location, that.location);
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(startDate, personalName, endDate, plantState, note, purchasedPrice, currencySymbol, seller,
+                            location
+        );
+    }
+}

--- a/backend/src/main/java/com/github/mdeluise/plantit/plant/info/PlantInfoDTOConverter.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plant/info/PlantInfoDTOConverter.java
@@ -1,0 +1,24 @@
+package com.github.mdeluise.plantit.plant.info;
+
+import com.github.mdeluise.plantit.common.AbstractDTOConverter;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PlantInfoDTOConverter extends AbstractDTOConverter<PlantInfo, PlantInfoDTO> {
+    public PlantInfoDTOConverter(ModelMapper modelMapper) {
+        super(modelMapper);
+    }
+
+
+    @Override
+    public PlantInfo convertFromDTO(PlantInfoDTO dto) {
+        return modelMapper.map(dto, PlantInfo.class);
+    }
+
+
+    @Override
+    public PlantInfoDTO convertToDTO(PlantInfo data) {
+        return modelMapper.map(data, PlantInfoDTO.class);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -30,7 +30,7 @@ spring.cache.redis.time-to-live            = ${CACHE_TTL:7200000}
 spring.liquibase.change-log                = classpath:/dblogs/changelog/changelog-master.xml
 spring.jpa.defer-datasource-initialization = false
 logging.level.liquibase                    = ${INTERNAL_LOG_LEVEL:TRACE}
-# TODO delete after update to v0.1.0
+# TODO delete after first official release of the project
 spring.liquibase.clear-checksums           = true
 
 

--- a/backend/src/main/resources/dblogs/changelog/changelog-master-dev.xml
+++ b/backend/src/main/resources/dblogs/changelog/changelog-master-dev.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <include file="/dblogs/changelog/changes/v0-0-0.xml"/>
+    <include file="/dblogs/changelog/changes/v1-0-0.xml"/>
     <include file="/dblogs/changelog/init-users.xml"/>
     <include file="/dblogs/changelog/init-dummy-data.xml"/>
 </databaseChangeLog>

--- a/backend/src/main/resources/dblogs/changelog/changelog-master-integration.xml
+++ b/backend/src/main/resources/dblogs/changelog/changelog-master-integration.xml
@@ -4,5 +4,5 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <include file="/dblogs/changelog/changes/v0-0-0.xml"/>
+    <include file="/dblogs/changelog/changes/v1-0-0.xml"/>
 </databaseChangeLog>

--- a/backend/src/main/resources/dblogs/changelog/changelog-master.xml
+++ b/backend/src/main/resources/dblogs/changelog/changelog-master.xml
@@ -4,5 +4,5 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <include file="/dblogs/changelog/changes/v0-0-0.xml"/>
+    <include file="/dblogs/changelog/changes/v1-0-0.xml"/>
 </databaseChangeLog>

--- a/backend/src/main/resources/dblogs/changelog/changes/v1-0-0.xml
+++ b/backend/src/main/resources/dblogs/changelog/changes/v1-0-0.xml
@@ -147,6 +147,14 @@
             </column>
             <column name="note" type="varchar(8500)">
             </column>
+            <column name="purchased_price" type="double">
+            </column>
+            <column name="currency_symbol" type="varchar(4)">
+            </column>
+            <column name="seller" type="varchar(100)">
+            </column>
+            <column name="location" type="varchar(100)">
+            </column>
             <column name="owner_id" type="bigint">
                 <constraints nullable="false" foreignKeyName="fk_plant_user" references="application_users(id)"/>
             </column>
@@ -337,6 +345,17 @@
             </column>
             <column name="ph_max" type="double" defaultValue="null">
                 <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <addColumn tableName="plants">
+            <column name="purchased_price" type="double" defaultValue="null">
+            </column>
+            <column name="currency_symbol" type="varchar(4)" defaultValue="null">
+            </column>
+            <column name="seller" type="varchar(100)" defaultValue="null">
+            </column>
+            <column name="location" type="varchar(100)" defaultValue="null">
             </column>
         </addColumn>
     </changeSet>

--- a/backend/src/main/resources/dblogs/changelog/init-dummy-data.xml
+++ b/backend/src/main/resources/dblogs/changelog/init-dummy-data.xml
@@ -92,6 +92,7 @@
             <column name="botanical_name_id" value="99"/>
             <column name="personal_name" value="Sedum spectabile"/>
             <column name="avatar_mode" value="NONE"/>
+            <column name="location" value="greenhouse 1"/>
         </insert>
         <insert tableName="plants">
             <column name="id" value="98"/>
@@ -101,6 +102,8 @@
             <column name="owner_id" value="99"/>
             <column name="botanical_name_id" value="98"/>
             <column name="avatar_mode" value="NONE"/>
+            <column name="location" value="greenhouse 2"/>
+            <column name="seller" value="Friend John"/>
         </insert>
         <insert tableName="plants">
             <column name="id" value="97"/>
@@ -118,6 +121,9 @@
                             and more recently with desktop publishing software like Aldus PageMaker
                             including versions of Lorem Ipsum."/>
             <column name="avatar_mode" value="NONE"/>
+            <column name="location" value="garden"/>
+            <column name="seller" value="Green Market Super Mega"/>
+            <column name="purchased_price" value="12.5"/>
         </insert>
     </changeSet>
 

--- a/backend/src/test/java/com/github/mdeluise/plantit/plant/controller/PlantControllerTest.java
+++ b/backend/src/test/java/com/github/mdeluise/plantit/plant/controller/PlantControllerTest.java
@@ -162,10 +162,10 @@ class PlantControllerTest {
         final Long plantId = 1L;
         final Plant updated = new Plant();
         updated.setId(plantId);
-        updated.setPersonalName(updatedPersonalName);
+        updated.getInfo().setPersonalName(updatedPersonalName);
         final PlantDTO updatedDTO = new PlantDTO();
         updatedDTO.setId(1L);
-        updatedDTO.setPersonalName(updatedPersonalName);
+        updatedDTO.getInfo().setPersonalName(updatedPersonalName);
 
         Mockito.when(plantService.update(plantId, updated)).thenReturn(updated);
         Mockito.when(plantDTOConverter.convertFromDTO(updatedDTO)).thenReturn(updated);

--- a/backend/src/test/java/com/github/mdeluise/plantit/plant/service/PlantServiceTest.java
+++ b/backend/src/test/java/com/github/mdeluise/plantit/plant/service/PlantServiceTest.java
@@ -160,8 +160,8 @@ class PlantServiceTest {
         final String personalName1 = "personal name to check 1";
         final String personalName2 = "personal name to check 2";
 
-        Mockito.when(plantRepository.existsByOwnerAndPersonalName(authenticatedUser, personalName1)).thenReturn(true);
-        Mockito.when(plantRepository.existsByOwnerAndPersonalName(authenticatedUser, personalName2)).thenReturn(false);
+        Mockito.when(plantRepository.existsByOwnerAndInfoPersonalName(authenticatedUser, personalName1)).thenReturn(true);
+        Mockito.when(plantRepository.existsByOwnerAndInfoPersonalName(authenticatedUser, personalName2)).thenReturn(false);
 
         SoftAssertions softly = new SoftAssertions();
         softly.assertThat(plantService.isNameAlreadyExisting(personalName1)).as("name exists correctly").isTrue();

--- a/frontend/src/common.ts
+++ b/frontend/src/common.ts
@@ -129,3 +129,43 @@ export const isVersionLessThan = (versionA: string, versionB: string): boolean =
     }
     return false;
 };
+
+export const getAllCurrencySymbols = (): string[] => {
+    const currencySymbols: string[] = [
+        "€", // Euro Sign
+        "$", // Dollar sign
+        "¢", // Cent sign
+        "₠", // European Currency
+        "₡", // Colon Sign
+        "₢", // Cruzeiro Sign
+        "₣", // French Franc Sign
+        "₤", // Lira Sign
+        "₥", // Mill Sign
+        "₦", // Naira Sign
+        "₧", // Peseta Sign
+        "₨", // Rupee Sign
+        "₩", // Won Sign
+        "₪", // New Sheqel Sign
+        "₫", // Dong Sign
+        "₭", // Kip Sign
+        "₮", // Tugrik Sign
+        "₯", // Drachma Sign
+        "₰", // German Penny Sign
+        "₱", // Peso Sign
+        "₲", // Guarani Sign
+        "₳", // Austral Sign
+        "₴", // Hryvnia Sign
+        "₵", // Cedi Sign
+        "₶", // Old Turkish Lira Sign
+        "₷", // Lira Sign
+        "₸", // Rupee Sign
+        "₹", // Indian Rupee Sign
+        "₺", // Turkish Lira Sign
+        "₻", // Tamil Rupee Sign
+        "₼", // Azerbaijani Manat Sign
+        "₽", // Russian Ruble Sign
+        "₾", // Lari Sign
+        "₿", // Bitcoin Sign
+    ];
+    return currencySymbols;
+}

--- a/frontend/src/components/AddLogEntry.tsx
+++ b/frontend/src/components/AddLogEntry.tsx
@@ -70,12 +70,12 @@ export default function AddLogEntry(props: {
                 props.requestor.post("diary/entry", {
                     type: eventType,
                     date: date,
-                    diaryId: props.plants.filter((en) => en.personalName === plantId)[0].diaryId,
+                    diaryId: props.plants.filter((en) => en.info.personalName === plantId)[0].diaryId,
                     note: note
                 })
                     .then((res) => {
                         res.data.diaryTargetPersonalName = plantId; // TODO should not be necessary but backend problem
-                        res.data.diaryTargetId = props.plants.filter((en) => en.personalName === plantId)[0].id;
+                        res.data.diaryTargetId = props.plants.filter((en) => en.info.personalName === plantId)[0].id;
                         props.updateLog(res.data);
                         closeDrawer();
                     })
@@ -121,7 +121,7 @@ export default function AddLogEntry(props: {
 
     useEffect(() => {
         if (props.addForPlant != undefined) {
-            setSelectedPlantName([props.addForPlant?.personalName]);
+            setSelectedPlantName([props.addForPlant?.info.personalName]);
         } else {
             setSelectedPlantName([]);
         }
@@ -166,7 +166,7 @@ export default function AddLogEntry(props: {
                         disableCloseOnSelect
                         disablePortal
                         multiple
-                        options={props.plants.map(pl => pl.personalName)}
+                        options={props.plants.map(pl => pl.info.personalName)}
                         disabled={props.addForPlant != undefined}
                         value={selectedPlantName}
                         onChange={(_event: any, newValue: readonly string[]) => changePlantName(newValue)}

--- a/frontend/src/components/AddPlant.tsx
+++ b/frontend/src/components/AddPlant.tsx
@@ -268,10 +268,12 @@ function AddPlantInfo(props: {
                             setUpdatedBotanicalInfo(addedBotanicalInfo);
                             const plantToCreate = {
                                 botanicalInfoId: addedBotanicalInfo.id,
-                                personalName: plantName!,
-                                state: "ALIVE",
-                                startDate: useDate ? date : null,
-                                note: note,
+                                info: {
+                                    personalName: plantName!,
+                                    state: "ALIVE",
+                                    startDate: useDate ? date : null,
+                                    note: note,
+                                },
                                 avatarMode: "NONE",
                             };
                             addNewPlant(plantToCreate)
@@ -284,10 +286,12 @@ function AddPlantInfo(props: {
                 } else {
                     const plantToCreate = {
                         botanicalInfoId: props.botanicalInfoToAdd.id,
-                        personalName: plantName!,
-                        state: "ALIVE",
-                        startDate: useDate ? date : null,
-                        note: note,
+                        info: {
+                            personalName: plantName!,
+                            state: "ALIVE",
+                            startDate: useDate ? date : null,
+                            note: note,
+                        },
                         avatarMode: "NONE",
                     }
                     addNewPlant(plantToCreate)

--- a/frontend/src/components/AllLogs.tsx
+++ b/frontend/src/components/AllLogs.tsx
@@ -77,10 +77,10 @@ function Filters(props: {
                         disableCloseOnSelect
                         disablePortal
                         multiple
-                        options={props.plants.map(pl => pl.personalName)}
+                        options={props.plants.map(pl => pl.info.personalName)}
                         value={selectedFilteredEntitiyNames}
                         onChange={(_event: any, newValue: readonly string[]) => {
-                            let selectedIds = props.plants.filter(pl => newValue.includes(pl.personalName)).map(pl => pl.id);
+                            let selectedIds = props.plants.filter(pl => newValue.includes(pl.info.personalName)).map(pl => pl.id);
                             props.setFilteredPlantIds(selectedIds);
                             setSelectedFilteredEntitiyNames(Array.from(newValue));
                         }}

--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -47,11 +47,11 @@ export default function (props: { requestor: AxiosInstance; }) {
                 "Authorization": 'Bearer ' + jwt
             }
         })
-            .then((response) => {
-                secureLocalStorage.setItem("plant-it-key", response.data.value);
+            .then(res => {
+                secureLocalStorage.setItem("plant-it-key", res.data.value);
                 navigate('/');
             })
-            .catch((_error) => {
+            .catch(_err => {
                 props.requestor.post("api-key/?name=" + apiKeyName, {}, {
                     headers: {
                         "Authorization": 'Bearer ' + jwt

--- a/frontend/src/components/EditEvent.tsx
+++ b/frontend/src/components/EditEvent.tsx
@@ -85,7 +85,7 @@ export default function EditEvent(props: {
     const [confirmDialogCallback, setConfirmDialogCallback] = useState<() => void>(() => () => { });
 
     const updateEvent = (): void => {
-        let newTarget: plant = props.plants.filter((en) => en.personalName === selectedPlantName)[0];
+        let newTarget: plant = props.plants.filter((en) => en.info.personalName === selectedPlantName)[0];
         props.requestor.put(`/diary/entry/${props.toEdit?.id}`, {
             type: selectedEventType,
             note: note,
@@ -179,9 +179,9 @@ export default function EditEvent(props: {
                             {props.plants.map((entity) => (
                                 <MenuItem
                                     key={entity.id}
-                                    value={entity.personalName}
+                                    value={entity.info.personalName}
                                 >
-                                    {entity.personalName}
+                                    {entity.info.personalName}
                                 </MenuItem>
                             ))}
                         </Select>

--- a/frontend/src/components/EditableTextField.tsx
+++ b/frontend/src/components/EditableTextField.tsx
@@ -8,7 +8,8 @@ export function EditableTextField(props: {
     onChange?: (arg: string) => void,
     variant?: "body1" | "h6",
     style?: {},
-    rows?: number;
+    rows?: number,
+    number?: boolean;
 }) {
     const [value, setValue] = useState<string>();
 
@@ -43,6 +44,7 @@ export function EditableTextField(props: {
                 ...props.style,
                 color: "black",
             }}
+            type={props.number ? "number" : undefined}
         />
         :
         <Typography

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -120,7 +120,7 @@ function UserPlantsList(props: {
             >
                 {
                     props.plants.filter(
-                        (en) => en.personalName.toLocaleLowerCase().includes(plantName.toLocaleLowerCase()))
+                        (en) => en.info.personalName.toLocaleLowerCase().includes(plantName.toLocaleLowerCase()))
                         .map((entity, index) => {
                             return <SwiperSlide
                                 key={entity.id}
@@ -215,7 +215,7 @@ export default function Home(props: { isLoggedIn: () => boolean, requestor: Axio
     };
 
     const getPlants = (count: number): void => {
-        props.requestor.get(`plant?sortBy=personalName&sortDir=ASC&pageSize=${count}`)
+        props.requestor.get(`plant?sortBy=infoPersonalName&sortDir=ASC&pageSize=${count}`)
             .then(res => {
                 let newPlants: plant[] = [];
                 res.data.content.forEach((en: plant) => {
@@ -292,7 +292,7 @@ export default function Home(props: { isLoggedIn: () => boolean, requestor: Axio
         const newLogEntries: diaryEntry[] = [...logEntries];
         newLogEntries.forEach(event => {
             if (event.diaryTargetId === updatedPlant.id) {
-                event.diaryTargetPersonalName = updatedPlant.personalName;
+                event.diaryTargetPersonalName = updatedPlant.info.personalName;
             }
         });
         setLogEntries(newLogEntries);

--- a/frontend/src/components/LogEntry.tsx
+++ b/frontend/src/components/LogEntry.tsx
@@ -11,6 +11,9 @@ import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import ShowerOutlinedIcon from '@mui/icons-material/ShowerOutlined';
 import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
 import WavesOutlinedIcon from '@mui/icons-material/WavesOutlined';
+import ContentCutIcon from '@mui/icons-material/ContentCut';
+import ChildCareIcon from '@mui/icons-material/ChildCare';
+import AddHomeIcon from '@mui/icons-material/AddHome';
 import { ReactElement } from "react";
 import { alpha } from "@mui/material";
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
@@ -25,13 +28,16 @@ export default function NewLogEntry(props: {
         switch (type.toLowerCase()) {
             case "watering": return <WaterDropOutlinedIcon />;
             case "seeding": return <YardOutlinedIcon />;
-            case "transplanting": return <AutorenewOutlinedIcon />;
+            case "transplanting": return <AddHomeIcon />;
             case "fertilizing": return <LunchDiningOutlinedIcon />;
             case "biostimulating": return <BatterySaverOutlinedIcon />;
             case "observation": return <VisibilityOutlinedIcon />;
             case "misting": return <ShowerOutlinedIcon />;
             case "treatment": return <ScienceOutlinedIcon />;
             case "water_changing": return <WavesOutlinedIcon />;
+            case "propagating": return <ChildCareIcon />;
+            case "pruning": return <ContentCutIcon />;
+            case "repotting": return <AutorenewOutlinedIcon />;
             default: return <QuestionMarkOutlinedIcon />;
         }
     };
@@ -47,6 +53,9 @@ export default function NewLogEntry(props: {
             case "observation": return "rgb(92, 93, 94)";
             case "misting": return "rgb(4, 34, 77)";
             case "water_changing": return "rgb(120, 154, 201)";
+            case "propagating": return "rgb(249, 136, 136)";
+            case "pruning": return "rgb(165, 136, 249)";
+            case "repotting": return "rgb(7, 76, 211)";
             default: return "rgb(226, 233, 243)";
         }
     };

--- a/frontend/src/components/UserPlant.tsx
+++ b/frontend/src/components/UserPlant.tsx
@@ -25,7 +25,7 @@ export default function UserPlant(props: {
             })
             .catch(err => {
                 console.error(err);
-                props.printError(`Cannot load plant's avatar for ${props.entity.personalName}`);
+                props.printError(`Cannot load plant's avatar for ${props.entity.info.personalName}`);
             });
     };
 
@@ -105,7 +105,7 @@ export default function UserPlant(props: {
                     backdropFilter: "blur(3px)",
                 }}>
                     <Typography variant="h6" sx={{ color: "white" }}>
-                        {props.entity.personalName}
+                        {props.entity.info.personalName}
                     </Typography>
                 </Box>
             }

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -23,18 +23,26 @@ export interface plantCareInfo {
 
 export interface plant {
     id: number,
-    startDate?: Date,
-    endDate?: Date,
-    personalName: string,
-    state: "PURCHASED" | "PLANTED" | "ALIVE" | "GIFTED" | "DEAD",
     ownerId: number,
     diaryId: number,
-    note?: string,
     avatarMode: "NONE" | "RANDOM" | "LAST" | "SPECIFIED",
     avatarImageId?: string,
     botanicalInfoId: number,
     avatarImageUrl?: string;
+    info: plantInfo;
 };
+
+export interface plantInfo {
+    note?: string,
+    startDate?: Date,
+    endDate?: Date,
+    personalName: string,
+    state: "PURCHASED" | "PLANTED" | "ALIVE" | "GIFTED" | "DEAD",
+    purchasedPrice?: number,
+    currencySymbol?: string,
+    seller?: string,
+    location?: string;
+}
 
 export interface diaryEntry {
     id: number,

--- a/online-resources/documentation/content/support/contributing.md
+++ b/online-resources/documentation/content/support/contributing.md
@@ -13,7 +13,8 @@ You can submit any of this in the [github issues section of the repository](http
 If you fix a bug, please follow the contribution guideline in order to merge the fix in the repository.
 
 #### Feature development
-Let's discuss first possible solutions for the development before start working on that, please [open a feature request issue](https://github.com/MDeLuise/plant-it/issues/new?assignees=&labels=&projects=&template=feature_request.yml).
+
+Let's discuss first possible solutions for the development before start working on that, please [open a feature request issue](https://github.com/MDeLuise/plant-it/issues/new?assignees=&labels=feature+request&projects=&template=feature_request.yml).
 
 #### Contribution guideline
 To fix a bug or create a feature, follow these steps:


### PR DESCRIPTION
Hey Plant-it community!
<br/>

## What's new?
This PR introduces three new event types: propagating, pruning, and repotting.
Additionally, it adds new plant info fields such as purchased price, seller, and location.

## Why is it important?
As the project evolves, it's crucial to enhance the system's capabilities to better track plant-related activities and details. The introduction of these new event types and plant info fields enhances the user experience and provides more comprehensive plant management.

## How to Use?
Users can now navigate to the plant details page and access information about both the species and the individual plant through the newly introduced tab view. They can also record propagating, pruning, and repotting events for each plant, providing more comprehensive lifecycle tracking.

## Notes
The propagating event type is currently a simple event, but future PRs will introduce a "propagating relationship," enabling users to navigate from one plant to another that is propagated from the first.

## Screenshots
<p align="center">
  <img src="https://github.com/MDeLuise/plant-it/assets/66636702/d7f5cfbb-3800-44f6-9379-fc70d7b040f7" width="33%" />
  <img src="https://github.com/MDeLuise/plant-it/assets/66636702/479e21a5-d9a9-4ea8-9cb0-9b4847b26e77" width="33%" />
</p>
<br/>
<br/>
Cheers and happy planting! 🌿🌼