### PR TITLE
Simplify error responses

### DIFF
--- a/backend/src/main/java/com/github/mdeluise/plantit/exception/ControllerExceptionHandler.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/exception/ControllerExceptionHandler.java
@@ -1,55 +1,45 @@
 package com.github.mdeluise.plantit.exception;
 
-import java.util.Date;
-
+import com.github.mdeluise.plantit.exception.error.ErrorCode;
+import com.github.mdeluise.plantit.exception.error.ErrorMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.context.request.WebRequest;
 
 @ControllerAdvice
 @ResponseBody
 public class ControllerExceptionHandler {
 
     @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<ErrorMessage> entityNotFoundException(
-        ResourceNotFoundException ex,
-        WebRequest request) {
-        ErrorMessage message = new ErrorMessage(
-                HttpStatus.NOT_FOUND.value(),
-                new Date(),
-                ex.getMessage(),
-                request.getDescription(false),
-                ex.getCause() != null ? ex.getCause().getMessage() : null
+    public ResponseEntity<ErrorMessage> entityNotFoundException(ResourceNotFoundException ex) {
+        final ErrorMessage message = new ErrorMessage(
+            HttpStatus.NOT_FOUND.value(),
+            ErrorCode.RESOURCE_NOT_FOUND,
+            ex.getMessage()
         );
         return new ResponseEntity<>(message, HttpStatus.NOT_FOUND);
     }
 
+
     @ExceptionHandler(UnauthorizedException.class)
-    public ResponseEntity<ErrorMessage> unauthorizedException(
-        UnauthorizedException ex,
-        WebRequest request) {
-        ErrorMessage message = new ErrorMessage(
+    public ResponseEntity<ErrorMessage> unauthorizedException(UnauthorizedException ex) {
+        final ErrorMessage message = new ErrorMessage(
             HttpStatus.UNAUTHORIZED.value(),
-            new Date(),
-            ex.getMessage(),
-            request.getDescription(false),
-            ex.getCause() != null ? ex.getCause().getMessage() : null
+            ErrorCode.USER_UNAUTHORIZED,
+            ex.getMessage()
         );
         return new ResponseEntity<>(message, HttpStatus.UNAUTHORIZED);
     }
 
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorMessage> globalExceptionHandler(Exception ex, WebRequest request) {
-        ErrorMessage message = new ErrorMessage(
-                HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                new Date(),
-                ex.getMessage(),
-                request.getDescription(false),
-                ex.getCause() != null ? ex.getCause().getMessage() : null
+    public ResponseEntity<ErrorMessage> globalExceptionHandler(Exception ex) {
+        final ErrorMessage message = new ErrorMessage(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            ex.getMessage()
         );
         return new ResponseEntity<>(message, HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/backend/src/main/java/com/github/mdeluise/plantit/exception/ErrorMessage.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/exception/ErrorMessage.java
@@ -1,6 +1,0 @@
-package com.github.mdeluise.plantit.exception;
-
-import java.util.Date;
-
-public record ErrorMessage(int statusCode, Date timestamp, String message, String description, String cause) {
-}

--- a/backend/src/main/java/com/github/mdeluise/plantit/exception/error/ErrorCode.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/exception/error/ErrorCode.java
@@ -1,0 +1,8 @@
+package com.github.mdeluise.plantit.exception.error;
+
+public enum ErrorCode {
+    RESOURCE_NOT_FOUND,
+    USER_UNAUTHORIZED,
+    INTERNAL_SERVER_ERROR,
+    AUTHENTICATION_ERROR,
+}

--- a/backend/src/main/java/com/github/mdeluise/plantit/exception/error/ErrorMessage.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/exception/error/ErrorMessage.java
@@ -1,0 +1,4 @@
+package com.github.mdeluise.plantit.exception.error;
+
+public record ErrorMessage(int statusCode, ErrorCode errorCode, String message) {
+}

--- a/backend/src/main/java/com/github/mdeluise/plantit/security/apikey/ApiKeyFilter.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/security/apikey/ApiKeyFilter.java
@@ -1,11 +1,11 @@
 package com.github.mdeluise.plantit.security.apikey;
 
 import java.io.IOException;
-import java.util.Date;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.mdeluise.plantit.authentication.User;
-import com.github.mdeluise.plantit.exception.ErrorMessage;
+import com.github.mdeluise.plantit.exception.error.ErrorCode;
+import com.github.mdeluise.plantit.exception.error.ErrorMessage;
 import com.github.mdeluise.plantit.security.services.PasswordUserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -28,7 +28,8 @@ public class ApiKeyFilter extends OncePerRequestFilter {
 
 
     @Autowired
-    public ApiKeyFilter(ApiKeyService apiKeyService, PasswordUserDetailsService passwordUserDetailsService, ObjectMapper objectMapper) {
+    public ApiKeyFilter(ApiKeyService apiKeyService, PasswordUserDetailsService passwordUserDetailsService,
+                        ObjectMapper objectMapper) {
         this.apiKeyService = apiKeyService;
         this.passwordUserDetailsService = passwordUserDetailsService;
         this.objectMapper = objectMapper;
@@ -51,7 +52,8 @@ public class ApiKeyFilter extends OncePerRequestFilter {
 
 
     private void sendError(String message, HttpServletResponse response) throws IOException {
-        final ErrorMessage error = new ErrorMessage(HttpStatus.UNAUTHORIZED.value(), new Date(), message, "", "");
+        final ErrorMessage error =
+            new ErrorMessage(HttpStatus.UNAUTHORIZED.value(), ErrorCode.USER_UNAUTHORIZED, message);
         response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.getWriter().write(objectMapper.writeValueAsString(error));

--- a/backend/src/main/java/com/github/mdeluise/plantit/security/jwt/JwtTokenFilter.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/security/jwt/JwtTokenFilter.java
@@ -1,10 +1,10 @@
 package com.github.mdeluise.plantit.security.jwt;
 
 import java.io.IOException;
-import java.util.Date;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.mdeluise.plantit.exception.ErrorMessage;
+import com.github.mdeluise.plantit.exception.error.ErrorCode;
+import com.github.mdeluise.plantit.exception.error.ErrorMessage;
 import com.github.mdeluise.plantit.security.services.PasswordUserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -58,10 +58,8 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     private void sendError(String message, HttpServletResponse response) throws IOException {
         final ErrorMessage error = new ErrorMessage(
             HttpStatus.FORBIDDEN.value(),
-            new Date(),
-            message,
-            "",
-            ""
+            ErrorCode.AUTHENTICATION_ERROR,
+            message
         );
         response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);


### PR DESCRIPTION
Hey Plant-it community!
<br/>
I've made some enhancements to the error message responses to simplify and improve user experience.

## What's new?
I've streamlined the error messages across the application to make them more concise and user-friendly. Instead of lengthy error messages, users will now receive clear and straightforward error responses from the backend.

## Why is it important?
Improving the clarity of error messages is essential for enhancing user experience and reducing confusion. With simplified error messages, users can quickly understand what went wrong and take appropriate actions to resolve the issue.

## How to Use?
No specific actions are required from users. They will automatically benefit from the improved error message responses whenever they encounter errors while using the application.

## Notes
Frontend side needs to be updated in order to benefit from this.


<br/>
<br/>
Cheers and happy planting! 🌿🌼