### PR TITLE
Fixed issue with render of reminders fields

### DIFF
--- a/frontend/src/components/AddOrModifyReminder.tsx
+++ b/frontend/src/components/AddOrModifyReminder.tsx
@@ -1,11 +1,10 @@
 import { AxiosInstance } from "axios";
-import { reminder } from "../interfaces";
+import { reminder, reminderFrequency } from "../interfaces";
 import { Dialog, DialogContent, FormGroup, DialogActions, Button, DialogTitle, InputLabel, OutlinedInput, Select, MenuItem, Box, Switch, TextField } from "@mui/material";
 import { useEffect, useState } from "react";
 import { titleCase } from "../common";
 import { LocalizationProvider, DatePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import CheckBox from "@mui/icons-material/CheckBox";
 import dayjs, { Dayjs } from "dayjs";
 
 export function AddOrModifyReminder(props: {
@@ -31,23 +30,16 @@ export function AddOrModifyReminder(props: {
             setEnabled(props.entity.enabled);
             setUseEndDate(props.entity.end != undefined);
         } else {
-            setUpdatedReminder({
-                action: "SEEDING",
-                start: new Date(),
-                enabled: true,
-                frequency: {
-                    quantity: 0,
-                    unit: "DAYS",
-                },
-                repeatAfter: {
-                    quantity: 3,
-                    unit: "DAYS",
-                },
-            });
-            setEnabled(true);
-            setUseEndDate(false);
+            cleanup();
         }
     }, [props.entity]);
+
+
+    useEffect(() => {
+        if (!props.open) {
+            cleanup();
+        }
+    }, [props.open]);
 
 
     useEffect(() => {
@@ -60,6 +52,25 @@ export function AddOrModifyReminder(props: {
             .then(res => setEventTypes(res.data))
             .catch(props.printError);
     }, []);
+
+
+    const cleanup = (): void => {
+        setUpdatedReminder({
+            action: "SEEDING",
+            start: new Date(),
+            enabled: true,
+            frequency: {
+                quantity: 0,
+                unit: "DAYS",
+            },
+            repeatAfter: {
+                quantity: 3,
+                unit: "DAYS",
+            },
+        });
+        setEnabled(true);
+        setUseEndDate(false);
+    };
 
 
     const addOrEdit = (): void => {
@@ -104,7 +115,7 @@ export function AddOrModifyReminder(props: {
                     <InputLabel>Start date</InputLabel>
                     <LocalizationProvider dateAdapter={AdapterDayjs} >
                         <DatePicker
-                            value={dayjs(updatedReminder.start)}
+                            defaultValue={dayjs(updatedReminder.start)}
                             onChange={newValue => updatedReminder.start = newValue?.toDate()}
                             slotProps={{ textField: { fullWidth: true } }}
                             format="DD/MM/YYYY"
@@ -116,12 +127,18 @@ export function AddOrModifyReminder(props: {
                     <InputLabel>Frequency</InputLabel>
                     <Box sx={{ display: "flex", gap: "5px", justifyContent: "center", }}>
                         <TextField
-                            defaultValue={updatedReminder.frequency?.quantity}
+                            value={updatedReminder.frequency?.quantity}
                             type="number"
                             variant="standard"
                             InputProps={{ disableUnderline: false }}
                             onChange={e => {
-                                updatedReminder.frequency!.quantity = Number(e.target.value);
+                                setUpdatedReminder((prevState: Partial<reminder>) => ({
+                                    ...prevState!,
+                                    frequency: {
+                                        ...prevState.frequency,
+                                        quantity: Number(e.target.value)
+                                    } as reminderFrequency
+                                }));
                             }}
                             sx={{
                                 width: "45%",
@@ -172,12 +189,18 @@ export function AddOrModifyReminder(props: {
                     <InputLabel>Repeat after</InputLabel>
                     <Box sx={{ display: "flex", gap: "5px", justifyContent: "center", }}>
                         <TextField
-                            defaultValue={updatedReminder.repeatAfter?.quantity}
+                            value={updatedReminder.repeatAfter?.quantity}
                             type="number"
                             variant="standard"
                             InputProps={{ disableUnderline: false }}
                             onChange={e => {
-                                updatedReminder.repeatAfter!.quantity = Number(e.target.value);
+                                setUpdatedReminder((prevState: Partial<reminder>) => ({
+                                    ...prevState!,
+                                    repeatAfter: {
+                                        ...prevState.repeatAfter,
+                                        quantity: Number(e.target.value)
+                                    } as reminderFrequency
+                                }));
                             }}
                             sx={{
                                 width: "45%",

--- a/frontend/src/components/AddPlant.tsx
+++ b/frontend/src/components/AddPlant.tsx
@@ -334,7 +334,7 @@ function SpecieInfoDetails(props: {
                     <EditableTextField
                         editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatLightRequirement(props.updatedBotanicalInfo?.plantCareInfo?.light, props.editModeEnabled)}
-                        onChange={(newVal) => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, light: getNumberValueOrUndefined(newVal) }}
+                        onChange={newVal => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, light: getNumberValueOrUndefined(newVal) }}
                     />
                 </Box>
             }
@@ -347,7 +347,7 @@ function SpecieInfoDetails(props: {
                     <EditableTextField
                         editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatHumidityRequirement(props.updatedBotanicalInfo?.plantCareInfo?.humidity, props.editModeEnabled)}
-                        onChange={(newVal) => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, humidity: getNumberValueOrUndefined(newVal) }}
+                        onChange={newVal => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, humidity: getNumberValueOrUndefined(newVal) }}
                     />
                 </Box>
             }
@@ -360,7 +360,7 @@ function SpecieInfoDetails(props: {
                     <EditableTextField
                         editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatTemperatureRequirement(props.updatedBotanicalInfo?.plantCareInfo?.maxTemp, props.editModeEnabled)}
-                        onChange={(newVal) => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, maxTemp: getNumberValueOrUndefined(newVal) }}
+                        onChange={newVal => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, maxTemp: getNumberValueOrUndefined(newVal) }}
                     />
                 </Box>
             }
@@ -373,7 +373,7 @@ function SpecieInfoDetails(props: {
                     <EditableTextField
                         editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatTemperatureRequirement(props.updatedBotanicalInfo?.plantCareInfo?.minTemp, props.editModeEnabled)}
-                        onChange={(newVal) => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, minTemp: getNumberValueOrUndefined(newVal) }}
+                        onChange={newVal => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, minTemp: getNumberValueOrUndefined(newVal) }}
                     />
                 </Box>
             }
@@ -386,7 +386,7 @@ function SpecieInfoDetails(props: {
                     <EditableTextField
                         editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatPh(props.updatedBotanicalInfo?.plantCareInfo?.phMax)}
-                        onChange={(newVal) => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, phMax: getNumberValueOrUndefined(newVal) }}
+                        onChange={newVal => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, phMax: getNumberValueOrUndefined(newVal) }}
                     />
                 </Box>
             }
@@ -399,7 +399,7 @@ function SpecieInfoDetails(props: {
                     <EditableTextField
                         editable={props.editModeEnabled || !props.botanicalInfoToAdd}
                         text={formatPh(props.updatedBotanicalInfo?.plantCareInfo?.phMin)}
-                        onChange={(newVal) => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, phMin: getNumberValueOrUndefined(newVal) }}
+                        onChange={newVal => props.updatedBotanicalInfo!.plantCareInfo = { ...props.updatedBotanicalInfo!.plantCareInfo!, phMin: getNumberValueOrUndefined(newVal) }}
                     />
                 </Box>
             }
@@ -502,7 +502,7 @@ function PlantInfoDetails(props: {
                         {
                             getAllCurrencySymbols().map(symbol => {
                                 return <MenuItem value={symbol}>{symbol}</MenuItem>
-                            })
+                            }) 
                         }
                     </Select>
                 </Box>
@@ -538,7 +538,7 @@ function PlantInfoDetails(props: {
                     multiline
                     value={props.note}
                     rows={4}
-                    onChange={(e) => props.setNote(e.currentTarget.value)}
+                    onChange={e => props.setNote(e.currentTarget.value)}
                 >
                 </TextField>
             </Box>

--- a/frontend/src/components/PlantDetails.tsx
+++ b/frontend/src/components/PlantDetails.tsx
@@ -1068,7 +1068,6 @@ function PlantInfoDetails(props: {
                                     defaultValue={props.plant?.info.currencySymbol || ""}
                                     variant="standard"
                                     onChange={e => {
-                                        console.debug(e.target.value)
                                         props.setInfo({ ...props.plant?.info!, currencySymbol: e.target.value as (string | undefined) });
                                     }}
                                 >
@@ -1202,17 +1201,20 @@ function PlantInfoDetails(props: {
                 }
             </Box>
         }
-        <Box
-            className="plant-detail-section">
-            <Typography variant="h6">
-                Reminders
-            </Typography>
-            <ReminderList
-                plantId={props.plant?.id}
-                requestor={props.requestor}
-                printError={props.printError}
-            />
-        </Box>
+        {
+            props.editModeEnabled ||
+            <Box
+                className="plant-detail-section">
+                <Typography variant="h6">
+                    Reminders
+                </Typography>
+                <ReminderList
+                    plantId={props.plant?.id}
+                    requestor={props.requestor}
+                    printError={props.printError}
+                />
+            </Box>
+        }
         {
             !props.editModeEnabled && props.imageIds.length > 0 &&
             <Box className="plant-detail-entry">


### PR DESCRIPTION
Hey Plant-it community!

This PR fixes a problem that was affecting the rendering of the reminders fields in the application.

## What's New?
This update addresses an issue where the reminders fields were not rendering properly, causing inconvenience to users trying to manage their reminders. With this fix, the reminders fields now displays correctly, ensuring a smoother user experience.

## Why is it Important?
The proper rendering of the reminders fields is crucial for users who rely on our application to manage their schedules and tasks efficiently. By resolving this issue, we are enhancing the usability and reliability of our platform.

## How to Use?
No action is required from users to benefit from this fix. Simply navigate to the reminders section within the application, and you'll notice that the fields now renders as expected, allowing you to view and manage your reminders seamlessly.

Cheers and happy planting! 🌿🌼