### PR TITLE
Fix query with only whitespace

### DIFF
--- a/backend/src/main/java/com/github/mdeluise/plantit/plantinfo/PlantInfoExtractorFacade.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plantinfo/PlantInfoExtractorFacade.java
@@ -46,7 +46,8 @@ public class PlantInfoExtractorFacade {
         key = "{#partialPlantScientificName, #size, @authenticatedUserService.getAuthenticatedUser().id}"
     )
     public List<BotanicalInfo> extractPlants(String partialPlantScientificName, int size) {
-        logger.debug(String.format("Extract botanical info matching %s (size %s)", partialPlantScientificName, size));
-        return chainHead.extractPlants(partialPlantScientificName, size);
+        final String searchTerm = partialPlantScientificName.isBlank() ? "*" : partialPlantScientificName.trim();
+        logger.debug(String.format("Extract botanical info matching %s (size %s)", searchTerm, size));
+        return chainHead.extractPlants(searchTerm, size);
     }
 }


### PR DESCRIPTION
Hey Plant-it community!

This PR addresses the issue (#156) where a whitespace input in the search box caused an error. The solution involves adding a check to trim whitespace characters from the input before processing the search query.

Cheers and happy planting! 🌿🌼