### PR TITLE
Fix translation issue for reminder dropdown

### DIFF
--- a/frontend/lib/l10n/app_it.arb
+++ b/frontend/lib/l10n/app_it.arb
@@ -94,7 +94,7 @@
   "watering": "innaffiatura",
   "fertilizing": "fertilizzazione",
   "biostimulating": "biostimulazione",
-  "misting": "nebulizzato",
+  "misting": "nebulizzazione",
   "transplanting": "trapianto",
   "water_changing": "cambio acqua",
   "observation": "osservazione",

--- a/frontend/lib/reminders/reminder_add.dart
+++ b/frontend/lib/reminders/reminder_add.dart
@@ -113,7 +113,7 @@ class _AddReminderState extends State<AddReminder> {
                       initialValue: getLocaleEvent(context, "watering"),
                       text: AppLocalizations.of(context).events,
                       options: widget.env.eventTypes
-                          .map((e) => formatEventType(e))
+                          .map((e) => getLocaleEvent(context, e))
                           .toList(),
                       onSelectedItemsChanged: (event) {
                         setState(() {

--- a/frontend/lib/reminders/reminder_edit.dart
+++ b/frontend/lib/reminders/reminder_edit.dart
@@ -153,7 +153,7 @@ class _EditReminderState extends State<EditReminder> {
                       initialValue: getLocaleEvent(context, _toEdit.action!),
                       text: AppLocalizations.of(context).events,
                       options: widget.env.eventTypes
-                          .map((e) => formatEventType(e))
+                          .map((e) => getLocaleEvent(context, e))
                           .toList(),
                       onSelectedItemsChanged: (event) {
                         setState(() {


### PR DESCRIPTION
Hey Plant-it community!
<br/>

## What's new?
This pull request addresses the translation issue for the reminder dropdown (https://github.com/MDeLuise/plant-it/issues/171).

## Why is it important?
Proper translation ensures a better user experience, allowing users to understand and interact with the application in their preferred language.

## How to Use?
No additional steps are required. Once merged, the translations for the reminder dropdown will be applied automatically.

<br/>
<br/>
Cheers and happy planting! 🌿🌼