### PR TITLE
feat: allow to customize Trefle url

### DIFF
--- a/backend/src/main/java/com/github/mdeluise/plantit/plantinfo/trafle/TrefleRequestMaker.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/plantinfo/trafle/TrefleRequestMaker.java
@@ -41,15 +41,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class TrefleRequestMaker {
     private final String token;
-    private final String domain = "https://trefle.io";
-    private final String baseEndpoint = domain + "/api/v1";
+    private final String domain;
+    private final String baseEndpoint;
     private final boolean trefleSSLVerification;
     private final Logger logger = LoggerFactory.getLogger(TrefleRequestMaker.class);
 
 
     @Autowired
-    public TrefleRequestMaker(@Value("${trefle.key}") String token,
+    public TrefleRequestMaker(@Value("${trefle.url}") String domain,
+                              @Value("${trefle.key}") String token,
                               @Value("${trefle.ssl.verification.enabled}") boolean trefleSSLVerification) {
+        this.domain = domain;
+        this.baseEndpoint = domain + "/api/v1";
         this.token = token;
         this.trefleSSLVerification = trefleSSLVerification;
     }

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -94,6 +94,7 @@ app.version                                 = @project.version@
 # System config
 #
 users.max                                   = ${USERS_LIMIT:-1}
+trefle.url                                  = ${TREFLE_URL:https://trefle.io}
 trefle.key                                  = ${TREFLE_KEY:}
 trefle.ssl.verification.enabled             = ${TREFLE_SSL_VERIFICATION:false}
 upload.location                             = ${UPLOAD_DIR:/tmp/plant-it}

--- a/backend/src/main/resources/application-integration.properties
+++ b/backend/src/main/resources/application-integration.properties
@@ -75,6 +75,7 @@ app.version                                     = @project.version@
 # System config
 #
 users.max                                       = ${USERS_LIMIT:-1}
+trefle.url                                      =
 trefle.key                                      =
 trefle.ssl.verification.enabled                 = ${TREFLE_SSL_VERIFICATION:false}
 upload.location                                 = ${UPLOAD_DIR:/tmp/plant-it}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -111,6 +111,7 @@ app.version                                      = @project.version@
 # System config
 #
 users.max                                        = ${USERS_LIMIT:-1}
+trefle.url                                       = ${TREFLE_URL:https://trefle.io}
 trefle.key                                       = ${TREFLE_KEY:}
 trefle.ssl.verification.enabled                  = ${TREFLE_SSL_VERIFICATION:false}
 upload.location                                  = ${UPLOAD_DIR:/upload-dir}


### PR DESCRIPTION
Hey Plant-it community!

Add an ability to specify custom Trefle Url. 

## Why is it important?
While you are working on another solution, I'm trying to deploy Trefle locally so that I can use Plant-it. Unfortunately, there is no way to change trefle domain available.

## How to Use?
Similarly to `trefle.key`, just set the custom server URL.