### PR TITLE
Add Gotify Notification Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,14 +150,14 @@ If you're interested in contributing transactions to enhance the app, you can ge
 |----------|----------|-------------|
 | English | app_en.arb | 100% |
 | Italian | app_it.arb | 100% |
-| German | app_de.arb | 100% |
-| Dutch Flemish | app_nl.arb | 100% |
-| Russian | app_ru.arb | 100% |
-| French | app_fr.arb | 99% |
-| Danish | app_da.arb | 99% |
-| Portuguese | app_pt.arb | 98% |
-| Ukrainian | app_uk.arb | 96% |
-| Spanish Castilian | app_es.arb | 96% |
+| Russian | app_ru.arb | 98% |
+| German | app_de.arb | 98% |
+| French | app_fr.arb | 98% |
+| Dutch Flemish | app_nl.arb | 98% |
+| Danish | app_da.arb | 98% |
+| Portuguese | app_pt.arb | 97% |
+| Ukrainian | app_uk.arb | 95% |
+| Spanish Castilian | app_es.arb | 95% |
 
 ### Bug Report, Feature Request and Question
 You can submit any of this in the [issues](https://github.com/MDeLuise/plant-it/issues/new/choose) section of the repository. Chose the right template and then fill the required info.

--- a/backend/src/main/java/com/github/mdeluise/plantit/notification/dispatcher/NotificationDispatcherController.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/notification/dispatcher/NotificationDispatcherController.java
@@ -5,6 +5,9 @@ import java.util.Set;
 
 import com.github.mdeluise.plantit.common.MessageResponse;
 import com.github.mdeluise.plantit.notification.dispatcher.config.AbstractNotificationDispatcherConfig;
+import com.github.mdeluise.plantit.notification.gotify.GotifyNotificationDispatcherConfig;
+import com.github.mdeluise.plantit.notification.gotify.GotifyNotificationDispatcherConfigDTO;
+import com.github.mdeluise.plantit.notification.gotify.GotifyNotificationDispatcherDTOConverter;
 import com.github.mdeluise.plantit.notification.ntfy.NtfyNotificationDispatcherConfig;
 import com.github.mdeluise.plantit.notification.ntfy.NtfyNotificationDispatcherConfigDTO;
 import com.github.mdeluise.plantit.notification.ntfy.NtfyNotificationDispatcherDTOConverter;
@@ -24,13 +27,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationDispatcherController {
     private final NotificationDispatcherService notificationDispatcherService;
     private final NtfyNotificationDispatcherDTOConverter ntfyNotificationDispatcherDTOConverter;
+    private final GotifyNotificationDispatcherDTOConverter gotifyNotificationDispatcherDTOConverter;
 
 
     @Autowired
     public NotificationDispatcherController(NotificationDispatcherService notificationDispatcherService,
-                                            NtfyNotificationDispatcherDTOConverter ntfyNotificationDispatcherDTOConverter) {
+                                            NtfyNotificationDispatcherDTOConverter ntfyNotificationDispatcherDTOConverter,
+                                            GotifyNotificationDispatcherDTOConverter gotifyNotificationDispatcherDTOConverter) {
         this.notificationDispatcherService = notificationDispatcherService;
         this.ntfyNotificationDispatcherDTOConverter = ntfyNotificationDispatcherDTOConverter;
+        this.gotifyNotificationDispatcherDTOConverter = gotifyNotificationDispatcherDTOConverter;
     }
 
 
@@ -50,7 +56,7 @@ public class NotificationDispatcherController {
 
 
     @GetMapping("/config/ntfy")
-    public NtfyNotificationDispatcherConfigDTO getConfig() {
+    public NtfyNotificationDispatcherConfigDTO getNtfyConfig() {
         final NtfyNotificationDispatcherConfig result =
             (NtfyNotificationDispatcherConfig) notificationDispatcherService.getUserConfig(NotificationDispatcherName.NTFY)
                                                                             .orElse(new NtfyNotificationDispatcherConfig());
@@ -59,9 +65,26 @@ public class NotificationDispatcherController {
 
 
     @PostMapping("/config/ntfy")
-    public ResponseEntity<MessageResponse> setConfig(@RequestBody NtfyNotificationDispatcherConfigDTO config) {
+    public ResponseEntity<MessageResponse> setNtfyConfig(@RequestBody NtfyNotificationDispatcherConfigDTO config) {
         final AbstractNotificationDispatcherConfig toSave = ntfyNotificationDispatcherDTOConverter.convertFromDTO(config);
         notificationDispatcherService.setUserConfig(NotificationDispatcherName.NTFY, toSave);
+        return ResponseEntity.ok(new MessageResponse("Success"));
+    }
+
+
+    @GetMapping("/config/gotify")
+    public GotifyNotificationDispatcherConfigDTO getGotifyConfig() {
+        final GotifyNotificationDispatcherConfig result =
+            (GotifyNotificationDispatcherConfig) notificationDispatcherService.getUserConfig(NotificationDispatcherName.GOTIFY)
+                                                                              .orElse(new GotifyNotificationDispatcherConfig());
+        return gotifyNotificationDispatcherDTOConverter.convertToDTO(result);
+    }
+
+
+    @PostMapping("/config/gotify")
+    public ResponseEntity<MessageResponse> setGotifyConfig(@RequestBody GotifyNotificationDispatcherConfigDTO config) {
+        final AbstractNotificationDispatcherConfig toSave = gotifyNotificationDispatcherDTOConverter.convertFromDTO(config);
+        notificationDispatcherService.setUserConfig(NotificationDispatcherName.GOTIFY, toSave);
         return ResponseEntity.ok(new MessageResponse("Success"));
     }
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/notification/dispatcher/NotificationDispatcherName.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/notification/dispatcher/NotificationDispatcherName.java
@@ -3,5 +3,6 @@ package com.github.mdeluise.plantit.notification.dispatcher;
 public enum NotificationDispatcherName {
     CONSOLE,
     EMAIL,
+    GOTIFY,
     NTFY
 }

--- a/backend/src/main/java/com/github/mdeluise/plantit/notification/gotify/GotifyNotificationDispatcher.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/notification/gotify/GotifyNotificationDispatcher.java
@@ -1,0 +1,98 @@
+package com.github.mdeluise.plantit.notification.gotify;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import com.github.mdeluise.plantit.notification.NotifyException;
+import com.github.mdeluise.plantit.notification.dispatcher.NotificationDispatcher;
+import com.github.mdeluise.plantit.notification.dispatcher.NotificationDispatcherName;
+import com.github.mdeluise.plantit.notification.dispatcher.config.NotificationDispatcherConfig;
+import com.github.mdeluise.plantit.reminder.Reminder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GotifyNotificationDispatcher implements NotificationDispatcher {
+    private final boolean enabled;
+    private String url;
+    private String token;
+    private final Logger logger = LoggerFactory.getLogger(GotifyNotificationDispatcher.class);
+
+
+    public GotifyNotificationDispatcher(@Value("${server.notification.gotify.enabled}") boolean enabled) {
+        this.enabled = enabled;
+    }
+
+
+    public void notifyReminder(Reminder reminder) throws NotifyException {
+        final HttpClient httpClient = HttpClient.newHttpClient();
+        final URI uri = URI.create(url).resolve("/message?token=" + token);
+        final String title = reminder.getTarget().getInfo().getPersonalName();
+        final String message = "Time to take care of " + title + ", action required: " + reminder.getAction();
+        final String body = String.format("{\"title\": \"%s\", \"message\": \"%s\"}", title, message);
+
+        final HttpRequest request = HttpRequest.newBuilder()
+                                               .uri(uri)
+                                               .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                                               .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                                               .build();
+
+        try {
+            final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            final int statusCode = response.statusCode();
+            if (statusCode < 200 || statusCode >= 300) {
+                throw new NotifyException("Failed to send notification. Response code: " + statusCode +
+                                              " Response body: " + response.body());
+            }
+        } catch (Exception e) {
+            throw new NotifyException(e);
+        }
+    }
+
+
+    @Override
+    public NotificationDispatcherName getName() {
+        return NotificationDispatcherName.GOTIFY;
+    }
+
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+
+    @Override
+    public void loadConfig(NotificationDispatcherConfig config) {
+        if (!(config instanceof GotifyNotificationDispatcherConfig gotifyConfig)) {
+            throw new UnsupportedOperationException(
+                "Configuration provided must be of type GotifyNotificationDispatcherConfig");
+        }
+        checkConfigParameters(gotifyConfig);
+        url = gotifyConfig.getUrl();
+        token = gotifyConfig.getToken();
+    }
+
+
+    @Override
+    public void initConfig() {
+        url = null;
+        token = null;
+    }
+
+
+    private void checkConfigParameters(GotifyNotificationDispatcherConfig gotifyConfig) {
+        if (gotifyConfig.getUrl() == null || gotifyConfig.getToken() == null) {
+            final String errorMsg = "Gotify url and token must be provided.";
+            logger.error(errorMsg);
+            throw new IllegalArgumentException(errorMsg);
+        }
+    }
+}

--- a/backend/src/main/java/com/github/mdeluise/plantit/notification/gotify/GotifyNotificationDispatcherConfig.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/notification/gotify/GotifyNotificationDispatcherConfig.java
@@ -1,0 +1,44 @@
+package com.github.mdeluise.plantit.notification.gotify;
+
+import com.github.mdeluise.plantit.notification.dispatcher.config.AbstractNotificationDispatcherConfig;
+import com.github.mdeluise.plantit.notification.dispatcher.config.NotificationDispatcherConfig;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "gotify_notification_configs")
+public class GotifyNotificationDispatcherConfig extends AbstractNotificationDispatcherConfig {
+    private String url;
+    private String token;
+
+
+    public String getUrl() {
+        return url;
+    }
+
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+
+    public String getToken() {
+        return token;
+    }
+
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+
+    @Override
+    public void update(NotificationDispatcherConfig updated) {
+        if (!(updated instanceof GotifyNotificationDispatcherConfig)) {
+            throw new UnsupportedOperationException("Updated class must be of type GotifyNotificationDispatcherConfig");
+        }
+        final GotifyNotificationDispatcherConfig gotifyUpdated = (GotifyNotificationDispatcherConfig) updated;
+        this.setUrl(gotifyUpdated.getUrl());
+        this.setToken(gotifyUpdated.getToken());
+    }
+}

--- a/backend/src/main/java/com/github/mdeluise/plantit/notification/gotify/GotifyNotificationDispatcherConfigDTO.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/notification/gotify/GotifyNotificationDispatcherConfigDTO.java
@@ -1,0 +1,43 @@
+package com.github.mdeluise.plantit.notification.gotify;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "Gotify notification config", description = "Represents the gotify notifier configuration")
+public class GotifyNotificationDispatcherConfigDTO {
+    @Schema(description = "id of the config", accessMode = Schema.AccessMode.READ_ONLY)
+    private String id;
+    @Schema(description = "url of the gotify server")
+    private String url;
+    @Schema(description = "token for auth in the gotify server")
+    private String token;
+
+
+    public String getId() {
+        return id;
+    }
+
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+
+    public String getUrl() {
+        return url;
+    }
+
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+
+    public String getToken() {
+        return token;
+    }
+
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/backend/src/main/java/com/github/mdeluise/plantit/notification/gotify/GotifyNotificationDispatcherDTOConverter.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/notification/gotify/GotifyNotificationDispatcherDTOConverter.java
@@ -1,0 +1,27 @@
+package com.github.mdeluise.plantit.notification.gotify;
+
+import com.github.mdeluise.plantit.common.AbstractDTOConverter;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GotifyNotificationDispatcherDTOConverter extends
+    AbstractDTOConverter<GotifyNotificationDispatcherConfig, GotifyNotificationDispatcherConfigDTO> {
+    public GotifyNotificationDispatcherDTOConverter(ModelMapper modelMapper) {
+        super(modelMapper);
+    }
+
+
+    @Override
+    public GotifyNotificationDispatcherConfig convertFromDTO(
+        GotifyNotificationDispatcherConfigDTO dto) {
+        return modelMapper.map(dto, GotifyNotificationDispatcherConfig.class);
+    }
+
+
+    @Override
+    public GotifyNotificationDispatcherConfigDTO convertToDTO(
+        GotifyNotificationDispatcherConfig data) {
+        return modelMapper.map(data, GotifyNotificationDispatcherConfigDTO.class);
+    }
+}

--- a/backend/src/main/java/com/github/mdeluise/plantit/notification/ntfy/NtfyNotificationDispatcher.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/notification/ntfy/NtfyNotificationDispatcher.java
@@ -42,7 +42,6 @@ public class NtfyNotificationDispatcher implements NotificationDispatcher {
                                                                   reminder.getTarget().getInfo().getPersonalName())
                                                               .header("X-Tags", "seedling");
 
-        // Set request body
         final String requestBody =
             "Time to take care of " + reminder.getTarget().getInfo().getPersonalName() + ", action required: " +
                 reminder.getAction();
@@ -50,7 +49,6 @@ public class NtfyNotificationDispatcher implements NotificationDispatcher {
             HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8);
         requestBuilder.method("POST", bodyPublisher);
 
-        // Set authentication based on provided credentials
         if (username != null && password != null) {
             final String credentials = username + ":" + password;
             final String basicAuth = "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes());
@@ -63,7 +61,6 @@ public class NtfyNotificationDispatcher implements NotificationDispatcher {
             final HttpRequest httpRequest = requestBuilder.build();
             final HttpResponse<String> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
 
-            // Handle response
             int statusCode = response.statusCode();
             if (statusCode < 200 || statusCode >= 300) {
                 throw new NotifyException("Failed to send notification. Response code: " + statusCode);

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -22,7 +22,7 @@ spring.jpa.hibernate.ddl-auto               = update
 
 
 #
-# RATE LIMITING
+# Rate Limiting
 #
 #server.rateLimit.requestPerSeconds          = ${MAX_REQUESTS_PER_MINUTE:50}
 server.rateLimit.requestPerMinute           = ${MAX_REQUESTS_PER_MINUTE:100}
@@ -119,6 +119,7 @@ spring.servlet.multipart.max-file-size      = ${MAX_UPLOAD_IMG_SIZE:15MB}
 
 
 #
-# NTFY
+# Notification
 #
-server.notification.ntfy.enabled            = ${NTFY_ENABLED:true}
+server.notification.ntfy.enabled            = ${NTFY_ENABLED:false}
+server.notification.gotify.enabled          = ${GOTIFY_ENABLED:false}

--- a/backend/src/main/resources/application-integration.properties
+++ b/backend/src/main/resources/application-integration.properties
@@ -58,11 +58,10 @@ server.cors.allowed-origins                     = ${ALLOWED_ORIGINS:*}
 
 
 #
-# RATE LIMITING
+# Rate Limiting
 #
 #server.rateLimit.requestPerSeconds              = ${MAX_REQUESTS_PER_MINUTE:999}
 server.rateLimit.requestPerMinute               = ${MAX_REQUESTS_PER_MINUTE:99999}
-
 
 
 #
@@ -98,6 +97,7 @@ spring.servlet.multipart.max-file-size          = ${MAX_UPLOAD_IMG_SIZE:15MB}
 
 
 #
-# NTFY
+# Notification
 #
 server.notification.ntfy.enabled                = ${NTFY_ENABLED:false}
+server.notification.gotify.enabled              = ${GOTIFY_ENABLED:false}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -89,7 +89,7 @@ server.ssl.key-alias                             = server
 
 
 #
-# RATE LIMITING
+# Rate Limiting
 #
 #server.rateLimit.requestPerSeconds               = ${MAX_REQUESTS_PER_MINUTE:50}
 server.rateLimit.requestPerMinute                = ${MAX_REQUESTS_PER_MINUTE:999}
@@ -126,6 +126,8 @@ reminders.notify_check                           = ${REMINDER_NOTIFY_CHECK:0 30 
 trefle.ssl.verification.enabled                  = ${TREFLE_SSL_VERIFICATION:false}
 trefle.url                                       =
 trefle.key                                       =
+
+
 #
 # Image upload
 #
@@ -134,6 +136,7 @@ spring.servlet.multipart.max-file-size           = ${MAX_UPLOAD_IMG_SIZE:15MB}
 
 
 #
-# NTFY
+# Notification
 #
-server.notification.ntfy.enabled                 = ${NTFY_ENABLED:true}
+server.notification.ntfy.enabled                 = ${NTFY_ENABLED:false}
+server.notification.gotify.enabled               = ${GOTIFY_ENABLED:false}

--- a/backend/src/main/resources/dblogs/changelog/changes/v1-0-0.xml
+++ b/backend/src/main/resources/dblogs/changelog/changes/v1-0-0.xml
@@ -440,10 +440,10 @@
     </changeSet>
 
 
-    <changeSet id="createNotificationConfigTables" author="MDeLuise">
+    <changeSet id="createNtfyNotificationConfigTables" author="MDeLuise">
         <preConditions onFail="MARK_RAN">
             <not>
-                <tableExists tableName="notification_config"/>
+                <tableExists tableName="ntfy_notification_configs"/>
             </not>
         </preConditions>
 
@@ -461,6 +461,23 @@
         <addColumn tableName="application_users">
             <column name="notification_dispatchers" type="VARCHAR(255)"/>
         </addColumn>
+    </changeSet>
+
+
+    <changeSet id="createGotifyNotificationConfigTables" author="MDeLuise">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="gotify_notification_configs"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="gotify_notification_configs">
+            <column name="id" type="bigint">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="url" type="varchar(255)"/>
+            <column name="token" type="varchar(255)"/>
+        </createTable>
     </changeSet>
 
 

--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -387,5 +387,9 @@
   "success": "Success",
   "warning": "Warning",
   "ops": "Ops!",
-  "changeLanguage": "Change language"
+  "changeLanguage": "Change language",
+  "gotifyServerUrl": "Gotify server URL",
+  "gotifyServerToken": "Gotify server token",
+  "gotifySettings": "Gotify settings",
+  "gotifySettingsUpdated": "Gotify settings correctly updated"
 }

--- a/frontend/lib/l10n/app_it.arb
+++ b/frontend/lib/l10n/app_it.arb
@@ -388,5 +388,9 @@
   "success": "Successo",
   "warning": "Attenzione",
   "ops": "Ops!",
-  "changeLanguage": "Cambia lingua"
+  "changeLanguage": "Cambia lingua",
+  "gotifyServerUrl": "URL del server gotify",
+  "gotifyServerToken": "Token per il server gotify",
+  "gotifySettings": "Impostazioni gotify",
+  "gotifySettingsUpdated": "Configurazioni gotify aggiornate correttamente"
 }

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:plant_it/app_http_client.dart';
 import 'package:plant_it/commons.dart';
 import 'package:plant_it/environment.dart';
 import 'package:plant_it/events_notifier.dart';
+import 'package:plant_it/notify_conf_notifier.dart';
 import 'package:plant_it/set_server.dart';
 import 'package:plant_it/splash_screen.dart';
 import 'package:plant_it/template.dart';
@@ -71,6 +72,7 @@ void main() async {
       MultiProvider(
         providers: [
           ChangeNotifierProvider(create: (context) => EventsNotifier()),
+          ChangeNotifierProvider(create: (context) => NotifyConfNotifier()),
           ChangeNotifierProvider(create: (context) => LocaleProvider()),
         ],
         child: Container(

--- a/frontend/lib/more/change_notifications.dart
+++ b/frontend/lib/more/change_notifications.dart
@@ -6,7 +6,9 @@ import 'package:material_loading_buttons/material_loading_buttons.dart';
 import 'package:plant_it/app_exception.dart';
 import 'package:plant_it/commons.dart';
 import 'package:plant_it/environment.dart';
+import 'package:plant_it/notify_conf_notifier.dart';
 import 'package:plant_it/toast/toast_manager.dart';
+import 'package:provider/provider.dart';
 
 class ChangeNotificationsPage extends StatefulWidget {
   final Environment env;
@@ -43,6 +45,7 @@ class _ChangeNotificationsPageState extends State<ChangeNotificationsPage> {
       if (!mounted) return;
       widget.env.toastManager.showToast(context, ToastNotificationType.success,
           AppLocalizations.of(context).notificationUpdated);
+      Provider.of<NotifyConfNotifier>(context, listen: false).notify();
       Navigator.of(context).pop();
     } finally {
       setState(() {

--- a/frontend/lib/more/gotify_settings.dart
+++ b/frontend/lib/more/gotify_settings.dart
@@ -1,0 +1,166 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:plant_it/app_exception.dart';
+import 'package:plant_it/commons.dart';
+import 'package:plant_it/environment.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:plant_it/toast/toast_manager.dart';
+
+class GotifySettingsPage extends StatefulWidget {
+  final Environment env;
+  const GotifySettingsPage({
+    super.key,
+    required this.env,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _GotifySettingsPageState();
+}
+
+class _GotifySettingsPageState extends State<GotifySettingsPage> {
+  bool _showToken = true;
+  final TextEditingController _urlController = TextEditingController();
+  final TextEditingController _tokenController = TextEditingController();
+
+  void _loadGotifySettings() async {
+    try {
+      final response =
+          await widget.env.http.get('notification-dispatcher/config/gotify');
+      if (response.statusCode != 200) {
+        final String responseErr = json.decode(response.body)["message"];
+        widget.env.logger
+            .error("Error while retrieving gotify settings: $responseErr");
+        if (!mounted) return;
+        throw AppException(AppLocalizations.of(context).generalError);
+      }
+      if (!mounted) return;
+      final responseBody = json.decode(response.body);
+      _urlController.text = responseBody["url"] ?? "";
+      _tokenController.text = responseBody["token"] ?? "";
+    } catch (e, st) {
+      if (!mounted) return;
+      widget.env.logger.error(e, st);
+      widget.env.toastManager.showToast(context, ToastNotificationType.error,
+          AppLocalizations.of(context).noBackend);
+    }
+  }
+
+  void _updateGotifySettings() async {
+    try {
+      final response =
+          await widget.env.http.post('notification-dispatcher/config/gotify', {
+        "url": _urlController.text,
+        "token": _tokenController.text,
+      });
+      if (response.statusCode != 200) {
+        final String responseErr = json.decode(response.body)["message"];
+        widget.env.logger
+            .error("Error while updating gotify settings: $responseErr");
+        if (!mounted) return;
+        throw AppException(AppLocalizations.of(context).generalError);
+      }
+      if (!mounted) return;
+      widget.env.logger.info("gotify settings correctly updated");
+      widget.env.toastManager.showToast(context, ToastNotificationType.success,
+          AppLocalizations.of(context).gotifySettingsUpdated);
+      Navigator.of(context).pop();
+    } catch (e, st) {
+      if (!mounted) return;
+      widget.env.logger.error(e, st);
+      widget.env.toastManager.showToast(context, ToastNotificationType.error,
+          AppLocalizations.of(context).noBackend);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _loadGotifySettings();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(AppLocalizations.of(context).gotifySettings),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _updateGotifySettings,
+        //tooltip: AppLocalizations.of(context).addNewEvent,
+        child: const Icon(Icons.save_outlined),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: SingleChildScrollView(
+          child: Form(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: Text(
+                          AppLocalizations.of(context).gotifyServerUrl,
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                      TextFormField(
+                        controller: _urlController,
+                        decoration: const InputDecoration(
+                          border: OutlineInputBorder(),
+                        ),
+                        validator: (value) {
+                          if (value == null || !isValidUrl(value)) {
+                            return AppLocalizations.of(context).enterValidURL;
+                          }
+                          return null;
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 4),
+                          child: Text(
+                            AppLocalizations.of(context).gotifyServerToken,
+                            style: const TextStyle(fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                        TextFormField(
+                          controller: _tokenController,
+                          obscureText: !_showToken,
+                          decoration: InputDecoration(
+                            border: const OutlineInputBorder(),
+                            suffixIcon: IconButton(
+                              icon: Icon(_showToken
+                                  ? Icons.visibility
+                                  : Icons.visibility_off),
+                              onPressed: () {
+                                setState(() {
+                                  _showToken = !_showToken;
+                                });
+                              },
+                            ),
+                          ),
+                        ),
+                      ],
+                    ))
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/notify_conf_notifier.dart
+++ b/frontend/lib/notify_conf_notifier.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/foundation.dart';
+
+class NotifyConfNotifier extends ChangeNotifier {
+  void notify() {
+    notifyListeners();
+  }
+}

--- a/online-resources/documentation/docs/server-installation.md
+++ b/online-resources/documentation/docs/server-installation.md
@@ -116,13 +116,13 @@ LOG_LEVEL=DEBUG # could be: DEBUG, INFO, WARN, ERROR
 CONTACT_MAIL=foo@bar.com # address used as "contact" for template email
 REMINDER_NOTIFY_CHECK=0 30 7 * * * # 6-values crontab expression to set the check time for reminders
 MAX_REQUESTS_PER_MINUTE=100 # rate limiting of the upcoming requests
-NTFY_ENABLED=true # if "false" ntfy service won't be available as notification dispatcher
 
 #
-# SSL
+# Notification
 #
-SSL_ENABLED=false
-CERTIFICATE_PATH=/certificates/ # path to files to use for ssl. If on docker deployment leave as it is and change the volume binding in the docker-compose file if needed
+NTFY_ENABLED=true # if "false" ntfy service won't be available as notification dispatcher
+GOTIFY_ENABLED=true # if "false" ntfy service won't be available as notification dispatcher
+
 
 #
 # Cache


### PR DESCRIPTION
Hey Plant-it community!
<br/>
This PR fixes #258, i.e. introduce a new feature that adds support for Gotify notifications. This addition will allow users who use Gotify for their notification needs to integrate seamlessly with the application.

## What's new?
I have implemented Gotify notification support in the application. Users can now configure the application to send notifications via Gotify by setting up the appropriate server properties.

## Why is it important?
Many users and organizations utilize Gotify for their notification systems. By adding support for Gotify, we provide more flexibility and options for our users to integrate their preferred notification services.

## How to Use?
To enable Gotify notifications, you need to configure the new `GOTIFY_ENABLED=true` server property.

<br/>
<br/>
Cheers and happy planting! 🌿🌼

