### PR TITLE
Switch Base Image from Ubuntu to Alpine to Reduce Image Size

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,27 +1,15 @@
-FROM ubuntu:24.04
+FROM alpine:3.20.2
 
 # Determine architecture and set Java download URL accordingly
 ARG TARGETPLATFORM
 ARG JAVATARGET
+ARG JAVA_VERSION=21
 
-RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
-        JAVATARGET=linux-x64; \
-    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-        JAVATARGET=linux-aarch64; \
-    fi && \
-    apt-get update && \
-    apt-get install -y bash openssl tar wget python3 && \
-    wget "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_${JAVATARGET}_bin.tar.gz" -O java.tar.gz && \
-    tar xvf java.tar.gz && \
-    rm java.tar.gz && \
-    echo 'JAVA_HOME=/jdk-21.0.2/bin/java' >> /root/.bashrc && \
-    echo 'export PATH="/jdk-21.0.2/bin:$PATH"' >> /root/.bashrc;
-
-# Setup environment
-ENV PATH="jdk-21.0.2/bin/:${PATH}"
+RUN apk update && \
+    apk add bash openssl tar wget python3 openjdk${JAVA_VERSION}-jre
 
 # Create environment
-RUN mkdir /opt/app
+RUN mkdir -p /opt/app
 
 # Download dependencies
 RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -O /opt/app/wait-for-it.sh

--- a/deployment/start.sh
+++ b/deployment/start.sh
@@ -70,7 +70,7 @@ fi
 #######################
 #     Run backend     #
 #######################
-/jdk-21.0.2/bin/java -jar /opt/app/backend/app.jar &
+java -jar /opt/app/backend/app.jar &
 
 
 #######################


### PR DESCRIPTION
Hey Plant-it community!  
<br/>

I've made a significant change to the Docker configuration by switching the base image from Ubuntu to Alpine. This change is aimed at reducing the overall size of the Docker image and improving efficiency.

## What's new?
- **Base Image Change**: The Dockerfile now uses `alpine:3.20.2` instead of `ubuntu:24.04`.
- **Image Size Reduction**: This switch has considerably reduced the image size.

## Why is it important?
- **Smaller Image Size**: Using Alpine, which is a smaller base image compared to Ubuntu, helps in reducing the Docker image size. This not only saves disk space but can also improve download and deployment times.
- **Resource Efficiency**: A smaller image size can lead to more efficient use of resources, which is particularly beneficial for environments with limited resources, such as Raspberry Pi or VPS setups.

## How to Use?
The change will be implemented in the next project release.

<br/>
<br/>
Cheers and happy planting! 🌿🌼