### PR TITLE
Remove Deprecated SSL Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,6 @@ Installing Plant-it is pretty straight forward, in order to do so follow these s
   CACHE_TTL=86400
   CACHE_HOST=cache
   CACHE_PORT=6379
-
-  #
-  # SSL
-  #
-  SSL_ENABLED=false
-  CERTIFICATE_PATH=/certificates/
   ```
 * Run the docker compose file (`docker compose -f docker-compose.yml up -d`), then the service will be available at `localhost:3000`, while the REST API will be available at `localhost:8080/api` (`localhost:8080/api/swagger-ui/index.html` for the documentation of them).
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -79,16 +79,6 @@ spring.mail.properties.mail.smtp.starttls.enable = ${SMTP_START_TTL:true}
 
 
 #
-# SSL
-#
-server.ssl.enabled                               = ${SSL_ENABLED:false}
-server.ssl.key-store-type                        = PKCS12
-server.ssl.key-store                             = /opt/app/keystore.p12
-server.ssl.key-store-password                    =
-server.ssl.key-alias                             = server
-
-
-#
 # Rate Limiting
 #
 #server.rateLimit.requestPerSeconds               = ${MAX_REQUESTS_PER_MINUTE:50}

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,17 +1,15 @@
 FROM alpine:3.20.2
 
-# Determine architecture and set Java download URL accordingly
-ARG TARGETPLATFORM
-ARG JAVATARGET
+# Download dependencies
 ARG JAVA_VERSION=21
 
 RUN apk update && \
-    apk add bash openssl tar wget python3 openjdk${JAVA_VERSION}-jre
+    apk add bash wget python3 openjdk${JAVA_VERSION}-jre
 
 # Create environment
 RUN mkdir -p /opt/app
 
-# Download dependencies
+# Download external dependencies
 RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -O /opt/app/wait-for-it.sh
 
 # Copy project files

--- a/deployment/helm/templates/config.yml
+++ b/deployment/helm/templates/config.yml
@@ -17,5 +17,3 @@ data:
   CACHE_TTL: "{{ .Values.configmap.data.CACHE_TTL }}"
   CACHE_HOST: "{{ .Values.configmap.data.CACHE_HOST }}"
   CACHE_PORT: "{{ .Values.configmap.data.CACHE_PORT }}"
-  SSL_ENABLED: "{{ .Values.configmap.data.SSL_ENABLED }}"
-  CERTIFICATE_PATH: "{{ .Values.configmap.data.CERTIFICATE_PATH }}"

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -29,8 +29,6 @@ configmap:
     CACHE_TTL: 86400
     CACHE_HOST: cache-service
     CACHE_PORT: 6379
-    SSL_ENABLED: false
-    CERTIFICATE_PATH: /
 
 image:
   server:

--- a/deployment/kubernetes/config.yml
+++ b/deployment/kubernetes/config.yml
@@ -16,5 +16,3 @@ data:
   CACHE_TTL: "86400"
   CACHE_HOST: "cache-service"
   CACHE_PORT: "6379"
-  SSL_ENABLED: "false"
-  CERTIFICATE_PATH: "/"

--- a/deployment/start.sh
+++ b/deployment/start.sh
@@ -1,59 +1,6 @@
 #!/bin/bash
 
 #######################
-# Manage certificates #
-#######################
-CERTIFICATE_PATH_DESTINATION="/opt/app";
-
-if [ "$SSL_ENABLED" = "true" ]; then
-  echo "WARNING: SSL_ENABLED property is deprecated and will be removed in a future release."
-  echo "If you need to use SSL, consider using an app proxy like Traefik or Nginx."
-fi
-
-generate_certificates() {
-  echo -n "Generating self-signed certificate...";
-  openssl req -x509 -newkey rsa:4096 -keyout "$CERTIFICATE_PATH/app.key" \
-    -out "$CERTIFICATE_PATH/app.crt" -days 365 -nodes -subj "/CN=localhost";
-  echo "DONE";
-  generate_keystore;
-}
-
-
-generate_keystore() {
-  echo -n "Creating the PKCS12 keystore...";
-  openssl pkcs12 -export -out "$CERTIFICATE_PATH/keystore.p12" \
-    -inkey "$CERTIFICATE_PATH/app.key" -in "$CERTIFICATE_PATH/app.crt" \
-    -name server -password pass:
-  echo "DONE";
-}
-
-
-# If certificates does not exist in source, then generate them
-if [ ! -f "${CERTIFICATE_PATH}/app.crt" ] || [ ! -f "${CERTIFICATE_PATH}/app.key" ]; then
-  generate_certificates;
-fi
-
-# If keystore do not exist in source, then generate it
-if [ ! -f "${CERTIFICATE_PATH}/keystore.p12" ]; then
-  generate_keystore;
-fi
-
-# Copy source files if not updated in the destination
-if ! cmp -s "${CERTIFICATE_PATH_DESTINATION}/app.crt" "${CERTIFICATE_PATH}/app.crt" || \
-  ! cmp -s "${CERTIFICATE_PATH_DESTINATION}/app.key" "${CERTIFICATE_PATH}/app.key"; then
-    echo -n "Certificate files are not up-to-date. Copying them...";
-    cp "${CERTIFICATE_PATH}/app.crt" "${CERTIFICATE_PATH_DESTINATION}/app.crt";
-    cp "${CERTIFICATE_PATH}/app.key" "${CERTIFICATE_PATH_DESTINATION}/app.key";
-    cp "${CERTIFICATE_PATH}/keystore.p12" "${CERTIFICATE_PATH_DESTINATION}/keystore.p12";
-    echo "DONE";
-else
-  echo "Certificate files are up-to-date.";
-fi
-
-echo "SSL enabled: $SSL_ENABLED";
-
-
-#######################
 #     Wait for DB     #
 #######################
 # Check if DEV is not set or is set to "false"

--- a/online-resources/documentation/docs/server-installation.md
+++ b/online-resources/documentation/docs/server-installation.md
@@ -74,12 +74,6 @@ ALLOWED_ORIGINS=*
 CACHE_TTL=86400
 CACHE_HOST=cache
 CACHE_PORT=6379
-
-#
-# SSL
-#
-SSL_ENABLED=false
-CERTIFICATE_PATH=/certificates/
 ```
 
 * Run the docker compose file (`docker compose -f docker-compose.yml up -d`), then the service will be available at `localhost:3000`, while the REST API will be available at `localhost:8080/api` (`localhost:8080/api/swagger-ui/index.html` for the documentation of them).
@@ -122,7 +116,6 @@ MAX_REQUESTS_PER_MINUTE=100 # rate limiting of the upcoming requests
 #
 NTFY_ENABLED=true # if "false" ntfy service won't be available as notification dispatcher
 GOTIFY_ENABLED=true # if "false" ntfy service won't be available as notification dispatcher
-
 
 #
 # Cache
@@ -259,12 +252,6 @@ ALLOWED_ORIGINS=*
 CACHE_TTL=86400
 CACHE_HOST=cache
 CACHE_PORT=6379
-
-#
-# SSL
-#
-SSL_ENABLED=false
-CERTIFICATE_PATH=/certificates/
 ```
 
 ## Example of traefik deployment
@@ -344,91 +331,6 @@ SMTP_AUTH=true
 SMTP_START_TTL=true
 CONTACT_MAIL=your-email@gmail.com
 ```
-
-## Enable SSL
-!!! warning end "Deprecation"
-
-    Please be aware that SSL feature is deprecated.
-    If you want to use SSL, you can use some application proxy like [traefik](https://traefik.io/traefik/) or [nginx](https://nginx.org/).
-
-To enable SSL for your Plant-it deployment, follow these steps:
-
-1. **Set SSL Enabled Property**: Ensure that SSL is enabled by adding the property `SSL_ENABLED=true` to the `server.env` file.
-1. **Create Volume Binding**: Add a volume binding `"./certs:/certificates"` to the `server.env` services in your `docker-compose.yml` file. This allows the services to access SSL certificates stored in the `./certs` directory.
-
-### Complete Example
-Let's say that you want to run Plant-it on a server with IP `https://192.168.1.103` and want to have:
-
-* the backend on port `8089`,
-* the frontend on port `3009`.
-
-`docker-compose.yml`:
-```yaml
-name: plant-it
-services:
-  server:
-    image: msdeluise/plant-it-server:latest
-    env_file: server.env
-    depends_on:
-      - db
-      - cache
-    restart: unless-stopped
-    volumes:
-      - "./upload-dir:/upload-dir"
-      - "certs:/certificates"
-    ports:
-      - "8089:8080"
-      - "3009:3000"
-  db:
-    image: mysql:8.0
-    restart: always
-    env_file: server.env
-    volumes:
-      - "./db:/var/lib/mysql"
-  cache:
-    image: redis:7.2.1
-    restart: always
-```
-
-`server.env`:
-```properties
-MYSQL_HOST=db
-MYSQL_PORT=3306
-MYSQL_USERNAME=root
-MYSQL_PSW=root
-MYSQL_DATABASE=bootdb
-MYSQL_ROOT_PASSWORD=root
-JWT_SECRET=32characterscomplicatedsecret
-JWT_EXP=1
-USERS_LIMIT=2
-UPLOAD_DIR=/upload-dir
-API_PORT=8080
-CACHE_TTL=86400
-CACHE_HOST=cache
-CACHE_PORT=6379
-FLORACODEX_KEY=
-ALLOWED_ORIGINS=*
-SSL_ENABLED=true
-CERTIFICATE_PATH=/certificates/ 
-```
-
-This setup creates a self-hosted certificate for both the backend and frontend services.
-
-!!! info "Accept certificates"
-
-    In some cases, certain browsers may require explicit acceptance of certificates from both the frontend and backend of the application, even if they share the same certificate. This scenario typically arises when encountering a "Cannot connect to the backend" error message and SSL is enabled.
-    To resolve this issue, users may need to navigate to both the frontend and backend URLs of the application and manually accept the certificate presented by each. By acknowledging the certificates, users can establish a trusted connection between their browser and the application's frontend and backend servers, thereby resolving connectivity issues.
-
-### Provide Custom Certificate
-If you prefer to use your own certificate, simply place the `app.key` and `app.crt` files inside the `CERTIFICATE_PATH` folder.
-
-## Get the API Key
-In order to get the API key, it's needed to use the REST API of the service:
-
-1. Open your browser and navigate to `http://<server-ip>:<server-port>/api/swagger-ui/index.html`.
-2. Obtain a JWT token by calling the `POST /authentication/login` endpoint with your credentials.
-3. Set the JWT token in Swagger for the subsequent calls by using the "Authorize" button at the top.
-4. Create a new API key by calling the `POST /api-key` endpoint, optionally passing a name for the key.
 
 ## Homepage dashboard integration
 ![](assets/dashboard-homepage.png){ align=left; loading=lazy; style="max-width:400px;"}


### PR DESCRIPTION
Hey Plant-it community!
<br/>
In this update, I've removed the deprecated SSL feature from the project. This change is aimed at simplifying the setup and avoiding potential issues with outdated or unsupported SSL configurations.

## What's new?
I've eliminated the deprecated SSL configuration that was previously part of the setup. This change helps keep our codebase up-to-date with modern practices and reduces the potential for security vulnerabilities.

## Why is it important?
Removing deprecated features helps maintain a clean and lightweight codebase.

## How to Use?
For users who still need SSL functionality, I recommend using established solutions such as [Nginx](https://nginx.org/en/) or [Traefik](https://doc.traefik.io/traefik/). These tools offer comprehensive SSL support and are widely used in production environments.

## Notes
- If you have existing setups that rely on the deprecated SSL feature, you will need to transition to one of the suggested solutions for SSL management.

<br/>
<br/>
Cheers and happy planting! 🌿🌼