### PR TITLE
Fix email `FROM` address to ensure it matches SMTP username

### DIFF
--- a/backend/src/main/java/com/github/mdeluise/plantit/notification/email/EmailService.java
+++ b/backend/src/main/java/com/github/mdeluise/plantit/notification/email/EmailService.java
@@ -31,6 +31,7 @@ public class EmailService implements NotificationDispatcher {
     private final TemporaryPasswordService temporaryPasswordService;
     private final String contactEmail;
     private final boolean enabled;
+    private final String from;
     private final Logger logger = LoggerFactory.getLogger(EmailService.class);
 
 
@@ -39,13 +40,15 @@ public class EmailService implements NotificationDispatcher {
     public EmailService(JavaMailSender emailSender, SpringTemplateEngine templateEngine, OtpService otpService,
                         TemporaryPasswordService temporaryPasswordService,
                         @Value("${server.owner.contact}") String contactEmail,
-                        @Value("${spring.mail.host}") String smtpHost) throws EmailException {
+                        @Value("${spring.mail.host}") String smtpHost,
+                        @Value("${spring.mail.username}") String from) throws EmailException {
         this.emailSender = emailSender;
         this.templateEngine = templateEngine;
         this.otpService = otpService;
         this.temporaryPasswordService = temporaryPasswordService;
         this.contactEmail = contactEmail;
         this.enabled = Strings.isNotEmpty(smtpHost);
+        this.from = from;
         if (isEnabled()) {
             checkConnection();
         }
@@ -230,6 +233,7 @@ public class EmailService implements NotificationDispatcher {
             helper = new MimeMessageHelper(mimeMessage, true);
             helper.setTo(to);
             helper.setSubject(subject);
+            helper.setFrom(from);
         } catch (MessagingException e) {
             logger.error("Error while setting mail to send", e);
             throw new EmailException(e);

--- a/backend/src/test/java/com/github/mdeluise/plantit/unit/service/EmailServiceUnitTests.java
+++ b/backend/src/test/java/com/github/mdeluise/plantit/unit/service/EmailServiceUnitTests.java
@@ -33,6 +33,7 @@ class EmailServiceUnitTests {
     private Transport transport;
     @Mock
     private MimeMessage mimeMessage;
+    private final String from = "test@test.com";
     private EmailService emailService;
 
 
@@ -41,7 +42,7 @@ class EmailServiceUnitTests {
         //Mockito.when(session.getTransport("smtp")).thenReturn(transport);
         Mockito.when(emailSender.createMimeMessage()).thenReturn(mimeMessage);
         emailService =
-            new EmailService(emailSender, templateEngine, otpService, temporaryPasswordService, "contact", "smtp");
+            new EmailService(emailSender, templateEngine, otpService, temporaryPasswordService, "contact", "smtp", from);
     }
 
 


### PR DESCRIPTION
Hey Plant-it community!  
<br/>

## What's new?
Thir PR fixes #289. I've implemented a fix to ensure that the `FROM` address in our outgoing emails consistently matches the SMTP username. This change prevents issues with certain mail servers, that enforce strict checks on the `FROM` address and could reject our emails if there's a mismatch.

## Why is it important?
By explicitly setting the `FROM` address to match the SMTP username, we ensure better email deliverability and improve the security of our email-sending process.

## How to Use?
No changes are required from the user side. The system will automatically use the correct `FROM` address when sending emails, ensuring consistency and reliability.

<br/>
<br/>
Cheers and happy planting! 🌿🌼
