### PR TITLE
Add shadow to back arrow on plant details screen for improved visibility

### DIFF
--- a/frontend/lib/plant_details/plant_details_page.dart
+++ b/frontend/lib/plant_details/plant_details_page.dart
@@ -106,6 +106,16 @@ class _PlantDetailsPageState extends State<PlantDetailsPage> {
                 (BuildContext context, bool innerBoxIsScrolled) {
               return <Widget>[
                 SliverAppBar(
+                  iconTheme: const IconThemeData(
+                    shadows: [
+                      BoxShadow(
+                        color: Colors.black,
+                        spreadRadius: 10,
+                        blurRadius: 10,
+                        offset: Offset(0, 3),
+                      ),
+                    ],
+                  ),
                   pinned: true,
                   stretch: true,
                   expandedHeight: MediaQuery.of(context).size.height * .5,

--- a/frontend/lib/search/species_details_page.dart
+++ b/frontend/lib/search/species_details_page.dart
@@ -38,6 +38,16 @@ class _SpeciesDetailsPageState extends State<SpeciesDetailsPage> {
                 (BuildContext context, bool innerBoxIsScrolled) {
               return <Widget>[
                 SliverAppBar(
+                  iconTheme: const IconThemeData(
+                    shadows: [
+                      BoxShadow(
+                        color: Colors.black,
+                        spreadRadius: 10,
+                        blurRadius: 10,
+                        offset: Offset(0, 3),
+                      ),
+                    ],
+                  ),
                   pinned: true,
                   stretch: true,
                   expandedHeight: MediaQuery.of(context).size.height * .5,


### PR DESCRIPTION
Hey Plant-it community!  
<br/>

## What's new?
This PR fixes #282, i.e. adds a shadow to the back arrow on the plant details screen to improve its visibility, especially against a white background. This change helps the arrow stand out, making navigation easier for users.

## Why is it important?
The back arrow on the plant details screen was sometimes difficult to see against a white background, potentially leading to a poor user experience. Adding a shadow enhances the arrow's visibility, ensuring that users can easily find and use it.

## How to Use?
No special instructions are needed. The back arrow on the plant details screen will now automatically have a shadow, making it more distinguishable against various backgrounds.

## Screenshots
<img height="400" src="https://github.com/user-attachments/assets/72ced0c4-f189-4e20-b433-dfec5640f08d">

<br/>
<br/>
Cheers and happy planting! 🌿🌼
