### PR TITLE
Update email regex to support TLDs of any length

### DIFF
--- a/frontend/lib/signup.dart
+++ b/frontend/lib/signup.dart
@@ -74,7 +74,7 @@ class _SignupPageState extends State<SignupPage> {
 
   bool _isValidEmail(String email) {
     final RegExp emailRegex = RegExp(
-      r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$',
+      r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,}$',
       caseSensitive: false,
     );
     return emailRegex.hasMatch(email);


### PR DESCRIPTION
Hey Plant-it community!
<br/>
This PR fixes #274, i.e. updates the regular expression used for validating email addresses to accommodate Top-Level Domains (TLDs) of any length. 

## What's new?
- **Regex Update**: The regex pattern has been modified to allow TLDs with 2 or more characters, removing the previous limit of 4 characters. This change ensures compatibility with a wider range of TLDs, including newer and longer ones.

## Why is it important?
- **Support for Modern TLDs**: The previous regex did not support TLDs longer than 4 characters, which could exclude valid email addresses with TLDs such as `.photography` or `.green`. This update ensures that email validation is more robust and aligns with current domain naming practices.
- **Local and Custom TLDs**: The update addresses issues faced by users with local email servers or custom TLDs longer than 4 characters, ensuring better compatibility and functionality.

## How to Use?
- **Validation**: The updated regex will now correctly validate email addresses with TLDs of any length, improving the accuracy of email format checks.

<br/>
<br/>
Cheers and happy planting! 🌿🌼