### PR TITLE
Resolve error when adding duplicate genus species before page reload

### DIFF
--- a/frontend/lib/plant_add/add_plant_page.dart
+++ b/frontend/lib/plant_add/add_plant_page.dart
@@ -58,10 +58,11 @@ class _AddPlantPageState extends State<AddPlantPage> {
   void _createPlant() async {
     try {
       int speciesId = widget.species.id ?? -1;
+      SpeciesDTO? updatedSpecies;
       if (widget.species.id == null) {
-        speciesId = await _createSpecies();
+        updatedSpecies = await _createSpecies();
       }
-      _toCreate.speciesId = speciesId;
+      _toCreate.speciesId = updatedSpecies?.id ?? speciesId;
       _toCreate.info.state = "PURCHASED";
       final response = await widget.env.http.post("plant", _toCreate.toMap());
       final responseBody = json.decode(utf8.decode(response.bodyBytes));
@@ -76,14 +77,14 @@ class _AddPlantPageState extends State<AddPlantPage> {
       if (!mounted) return;
       widget.env.toastManager.showToast(context, ToastNotificationType.success,
           AppLocalizations.of(context).plantCreatedSuccessfully);
-      Navigator.pop(context, true);
+      Navigator.pop(context, updatedSpecies);
     } catch (e, st) {
       widget.env.logger.error(e, st);
       throw AppException.withInnerException(e as Exception);
     }
   }
 
-  Future<int> _createSpecies() async {
+  Future<SpeciesDTO> _createSpecies() async {
     try {
       final response =
           await widget.env.http.post("botanical-info", widget.species.toMap());
@@ -95,7 +96,7 @@ class _AddPlantPageState extends State<AddPlantPage> {
         throw AppException(AppLocalizations.of(context).errorCreatingSpecies);
       }
       widget.env.logger.info("Species successfully created");
-      return responseBody["id"];
+      return SpeciesDTO.fromJson(responseBody);
     } catch (e, st) {
       widget.env.logger.error(e, st);
       throw AppException.withInnerException(e as Exception);

--- a/frontend/lib/search/species_details_bottom_bar.dart
+++ b/frontend/lib/search/species_details_bottom_bar.dart
@@ -101,7 +101,11 @@ class SpeciesDetailsBottomActionBar extends StatelessWidget {
                       species: species,
                     ),
                   ),
-                ),
+                ).then((speciesCreated) {
+                  if (speciesCreated != null) {
+                    updateSpeciesLocally(speciesCreated);
+                  }
+                }),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [

--- a/frontend/lib/search/species_details_page.dart
+++ b/frontend/lib/search/species_details_page.dart
@@ -25,8 +25,8 @@ class SpeciesDetailsPage extends StatefulWidget {
 
 class _SpeciesDetailsPageState extends State<SpeciesDetailsPage> {
   void _updateSpeciesLocally(SpeciesDTO species) {
-    fetchAndSetPlants(context, widget.env);
     widget.updateSpeciesLocally(species);
+    fetchAndSetPlants(context, widget.env);
   }
 
   @override


### PR DESCRIPTION
Hey Plant-it community!
<br/>

## What's new?
This PR fixes #314, i.e. addresses an issue where attempting to add a plant from the same genus species that already exists in the user's collection would result in an error if the page is not reloaded before. The error was traced back to an assertion failure in Hibernate, which occurred during the collection initialization. 

## Why is it important?
User can now add multiple plants for a species belonging to floracodex without need to manually refresh the search page after the first plant added. 

## How to Use?
No additional actions are required from users.

<br/>
<br/>
Cheers and happy planting! 🌿🌼