### PR TITLE
Update app_de.arb

### DIFF
--- a/frontend/lib/l10n/app_de.arb
+++ b/frontend/lib/l10n/app_de.arb
@@ -95,7 +95,7 @@
   "fertilizing": "gedüngt",
   "biostimulating": "biostimuliert",
   "misting": "besprüht",
-  "transplanting": "umgetopft",
+  "transplanting": "umgepflanzt",
   "water_changing": "Wasser gewechselt",
   "observation": "Beobachtung",
   "treatment": "Behandlung",


### PR DESCRIPTION
Change translation for "transplanting" from "umgetopft" to "umgepflanzt", because "transplanting" and "repotting" was both translated with "umgetopft".
