### PR TITLE
fix(lang): typo in english ("porvided" -> "provided")

### DIFF
--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -112,7 +112,7 @@
   "enterApiKey": "Enter API Key",
   "enableDataSource": "Enable data source",
   "apiKey": "API Key",
-  "notProvided": "not porvided",
+  "notProvided": "not provided",
   "appInfo": "App Info",
   "appVersion": "App version",
   "sourceCode": "Source code",


### PR DESCRIPTION
Hey Plant-it community!
<br/>
This fixes a typo in English translation.

<br/>
<br/>
Cheers and happy planting! 🌿🌼