### PR TITLE
fix(search): prevent null cast crash when retrying failed search

### DIFF
--- a/frontend/lib/ui/search/widgets/search_page.dart
+++ b/frontend/lib/ui/search/widgets/search_page.dart
@@ -31,40 +31,32 @@ class SearchPage extends StatefulWidget {
 class _SearchPageState extends State<SearchPage> {
   final TextEditingController _searchController = TextEditingController();
 
+  // Tracks the most recent Query so "Try again" can re-execute it.
+  // Passing `search.execute` directly as a VoidCallback would invoke it with
+  // a null argument, which crashes when the Command casts to Query.
+  Query _lastQuery = Query(term: "", offset: 0, limit: 10);
+
+  void _runSearch(Query query) {
+    _lastQuery = query;
+    widget.viewModel.search.execute(query);
+  }
+
   @override
   void initState() {
     super.initState();
     _searchController.addListener(() {
       if (_searchController.text.isEmpty) {
-        widget.viewModel.search.execute(
-          Query(
-            term: "",
-            offset: 0,
-            limit: 10,
-          ),
-        );
+        _runSearch(Query(term: "", offset: 0, limit: 10));
       }
     });
     widget.streamController.stream.listen((_) {
-      widget.viewModel.search.execute(
-        Query(
-            term: "",
-            offset: 0,
-            limit: 10,
-          ),
-      );
+      _runSearch(Query(term: "", offset: 0, limit: 10));
     });
   }
 
   void _onSearchSubmitted(String value) {
     if (value.isNotEmpty) {
-      widget.viewModel.search.execute(
-        Query(
-          term: value,
-          offset: 0,
-          limit: 10,
-        ),
-      );
+      _runSearch(Query(term: value, offset: 0, limit: 10));
     }
   }
 
@@ -84,7 +76,7 @@ class _SearchPageState extends State<SearchPage> {
               return ErrorIndicator(
                 title: L.of(context).errorWithMessage(command.error.toString()),
                 label: L.of(context).tryAgain,
-                onPressed: widget.viewModel.search.execute,
+                onPressed: () => _runSearch(_lastQuery),
               );
             }
 


### PR DESCRIPTION
Hey Plant-it community!

This fixes the crash reported in #589 when tapping "Try Again" after a failed species search.

## What's new?
`SearchPage` now tracks the most recent `Query` in state and re-runs it explicitly when the user taps the retry button. Previously the button passed `search.execute` directly as its `VoidCallback`.

## Why is it important?
Because `search` is declared `Command<Query, void>`, invoking `execute()` without a `Query` argument triggered a null cast to the non-nullable type, throwing:

```
type 'Null' is not a subtype of type 'Query' in type cast
```

That's the second error in #589 — the user saw it any time a search failed (no network, bad API key, FloraCodex error) and tapped Try Again. The app crashed instead of retrying.

This PR does not address the first error in #589 (the FloraCodex failure surfacing itself); I plan to open follow-up PRs for related issues (stale search cache, API key input sanitization).

## How to Use?
Unchanged from the user's perspective — "Try Again" now actually retries the last search instead of crashing.

## Notes
- Scope: a single state field and helper method in `_SearchPageState`; no public API changes.
- `flutter analyze` is clean on the modified file; `flutter test` passes.
- Verified manually on a Samsung S21 (Android 15): reproduced the crash on v1.0.1+11, then confirmed the fix by enabling airplane mode, searching "monstera", tapping Try Again — same error re-displays (expected), no crash.

Refs #589