### PR TITLE
fix(settings): sanitize pasted FloraCodex API key

### DIFF
--- a/frontend/lib/ui/settings/widgets/data_sources_screen.dart
+++ b/frontend/lib/ui/settings/widgets/data_sources_screen.dart
@@ -10,6 +10,22 @@ import 'package:plant_it/ui/settings/view_models/settings_viewmodel.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:workmanager/workmanager.dart';
 
+// Strips leading/trailing whitespace and cuts the string at the first
+// URL-fragment character (& ? # whitespace). Users pasting from their
+// FloraCodex dashboard URL sometimes include trailing query fragments like
+// "&q"; left unsanitized these inject a second `q=` parameter into the
+// search URL, which makes FloraCodex return empty results silently.
+String _sanitizeApiKey(String raw) {
+  final trimmed = raw.trim();
+  const delimiters = ['&', '?', '#', ' ', '\n', '\t', '\r'];
+  int cut = trimmed.length;
+  for (final d in delimiters) {
+    final idx = trimmed.indexOf(d);
+    if (idx != -1 && idx < cut) cut = idx;
+  }
+  return trimmed.substring(0, cut);
+}
+
 class DataSourcesScreen extends StatelessWidget {
   final SettingsViewModel viewModel;
   const DataSourcesScreen({
@@ -72,7 +88,7 @@ class FloraCodexScreen extends StatelessWidget {
             ),
             TextButton(
               onPressed: () {
-                String apiKey = controller.text.trim();
+                String apiKey = _sanitizeApiKey(controller.text);
                 if (apiKey.isNotEmpty) {
                   viewModel.save.executeWithFuture({
                     UserSettingsKeys.floraCodexKey.key: apiKey,


### PR DESCRIPTION
Hey Plant-it community!

This fixes the silent empty-search scenario when a user pastes a FloraCodex key with URL-fragment garbage attached (e.g., trailing \`&q\`).

## What's new?
The FloraCodex API key dialog now strips leading/trailing whitespace and cuts the string at the first URL-fragment character (\`&\`, \`?\`, \`#\`, whitespace) before saving. Previously only \`.trim()\` was applied.

## Why is it important?
When users generate an API key on FloraCodex's site, it's easy to copy text that includes nearby URL-query fragments (e.g., \`dqjIQC9aiTx...&q\`). The app stored that verbatim, then appended it to the search URL as:

\`\`\`
.../species/search?q=monstera&limit=10&page=0&key=dqjIQC9aiTx...&q
\`\`\`

The trailing \`&q\` introduces a second \`q=\` parameter (empty). FloraCodex picks up the empty one, so every search returns \`{"data": [], "meta": {"total": 0}}\` with HTTP 200. The user sees "no results" for every query and has no way to tell something's wrong.

Sanitizing on save handles the common paste-mistake cleanly.

## How to Use?
No user-facing change — existing valid keys are untouched. Next time someone pastes a key, any trailing URL junk is stripped before storage.

## Notes
- Scope: one small private helper plus one callsite change in \`data_sources_screen.dart\`.
- Sanitization is applied only at save time; stored keys aren't migrated. Users with an already-corrupted key will need to re-paste once (same as they'd need to fix manually today).
- \`flutter analyze\` clean on the modified file; \`flutter test\` passes (5/5).
- Verified manually on Samsung S21: pasted key with \`&q\` suffix, saved, searched "basil" — results returned cleanly.

Refs #589