### PR TITLE
fix(species): guard against present-but-null external avatar URL

### DIFF
--- a/frontend/lib/ui/species/view_models/view_species_viewmodel.dart
+++ b/frontend/lib/ui/species/view_models/view_species_viewmodel.dart
@@ -151,7 +151,12 @@ class ViewSpeciesViewModel extends ChangeNotifier {
     _speciesSynonyms = details.getOrThrow().speciesSynonymsCompanion;
     _log.fine("External species synonyms loaded");
 
-    if (details.getOrThrow().speciesCompanion.externalAvatarUrl.present) {
+    // Drift's `.present` is true for both `Value(something)` and `Value(null)`,
+    // so we also have to guard against a present-but-null URL. FloraCodex
+    // can return a species with no `image_url`, which would otherwise crash
+    // with "null check operator used on a null value" at `.value!` below.
+    if (details.getOrThrow().speciesCompanion.externalAvatarUrl.present &&
+        details.getOrThrow().speciesCompanion.externalAvatarUrl.value != null) {
       String url =
           details.getOrThrow().speciesCompanion.externalAvatarUrl.value!;
 


### PR DESCRIPTION
Hey Plant-it community!

This fixes a "null check operator used on a null value" crash that happens when opening the detail view for certain external species — one of the reproducible failure paths encountered while working through #589.

## What's new?
In \`ViewSpeciesViewModel._loadExternal\`, the check \`externalAvatarUrl.present\` gated a dereference via \`.value!\`. Drift's \`.present\` is true whenever a \`Value\` was explicitly constructed — including \`Value(null)\`. For species with no \`image_url\` from FloraCodex, \`externalAvatarUrl.value\` is null but \`.present\` is still true, so the \`!\` threw.

Add an explicit \`!= null\` check alongside \`.present\` before the dereference.

## Why is it important?
FloraCodex returns \`image_url: null\` for a meaningful portion of its catalogue (many algae, marine species, obscure genera — easy to hit from a casual "rose" search). Before this change, tapping any such species threw a null-check exception and the user saw a generic "null check operator used on a null value" error instead of the detail page. No image appears on the detail page either way; with the fix, the page just opens without an avatar.

## How to Use?
No behavior change for species that do have an image. Species without an image now render their detail screen correctly instead of crashing.

## Notes
- Scope: one conditional in \`view_species_viewmodel.dart\`, 6 lines changed.
- Comment added to explain drift's \`.present\` semantics so the next person doesn't trip on it.
- \`flutter analyze\` clean; \`flutter test\` passes (5/5).
- Verified on Samsung S21 by tapping several FloraCodex species with and without images.

Refs #589