### PR TITLE
docs: Correct typo in translations section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Please refer to the [Contributing Guidelines](contributing.md) for detailed inst
 
 ### Translations
 
-If you're interested in contributing transactions to enhance the app, you can get started by following the guide provided [here](https://github.com/MDeLuise/plant-it/discussions/148). Your support and contributions are greatly appreciated.
+If you're interested in contributing translations to enhance the app, you can get started by following the guide provided [here](https://github.com/MDeLuise/plant-it/discussions/148). Your support and contributions are greatly appreciated.


### PR DESCRIPTION
Minor typo in README.
