### PR TITLE
feat(search): send a User-Agent header on Flora Codex requests

### DIFF
--- a/frontend/lib/data/service/search/flora_codex_searcher.dart
+++ b/frontend/lib/data/service/search/flora_codex_searcher.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:drift/drift.dart';
 import 'package:http/http.dart' as http;
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:plant_it/data/repository/user_setting_repository.dart';
 import 'package:plant_it/data/service/search/species_searcher.dart';
 import 'package:plant_it/database/database.dart';
@@ -72,8 +74,9 @@ import 'package:result_dart/result_dart.dart';
 class FloraCodexSearcher extends SpeciesSearcher {
   final UserSettingRepository _userSettingRepository;
   final String baseUrl = "https://api.floracodex.com";
-  final String version = "/v1/";
+  final String version = "/v1";
   String? _apiKey;
+  String? _userAgent;
   bool _initialized = false;
 
   FloraCodexSearcher({
@@ -82,6 +85,21 @@ class FloraCodexSearcher extends SpeciesSearcher {
 
   void setKey(String? key) {
     _apiKey = key;
+  }
+
+  /// HTTP headers for every Flora Codex request. The User-Agent identifies the
+  /// app, its version, and the host platform (android/ios/macos/...). Built
+  /// once and memoized, since none of it changes within a run. Resolved lazily
+  /// here rather than only in [_initialize] because [getDetails] reaches the
+  /// network without going through [search]/[_initialize].
+  Future<Map<String, String>> _headers() async {
+    _userAgent ??= await _buildUserAgent();
+    return {"User-Agent": _userAgent!};
+  }
+
+  Future<String> _buildUserAgent() async {
+    final PackageInfo packageInfo = await PackageInfo.fromPlatform();
+    return "plant-it/${packageInfo.version} (${Platform.operatingSystem})";
   }
 
   @override
@@ -99,7 +117,8 @@ class FloraCodexSearcher extends SpeciesSearcher {
 
     final String url =
         "$baseUrl$version/species/search?q=$term&limit=$limit&page=0&key=$_apiKey";
-    final http.Response response = await http.get(Uri.parse(url));
+    final http.Response response =
+        await http.get(Uri.parse(url), headers: await _headers());
     if (response.statusCode != 200) {
       return Failure(Exception("Error while loading species from Flora Codex"));
     }
@@ -169,7 +188,8 @@ class FloraCodexSearcher extends SpeciesSearcher {
 
   Future<Result<SpeciesCompanion>> _getSpecies(String id) async {
     String url = "$baseUrl$version/species/$id?key=$_apiKey";
-    http.Response response = await http.get(Uri.parse(url));
+    http.Response response =
+        await http.get(Uri.parse(url), headers: await _headers());
     if (response.statusCode != 200) {
       return Failure(Exception("Error while loading species from Flora Codex"));
     }
@@ -207,7 +227,8 @@ class FloraCodexSearcher extends SpeciesSearcher {
 
   Future<Result<List<SpeciesSynonymsCompanion>>> _getSynonyms(String id) async {
     String url = "$baseUrl$version/species/$id?key=$_apiKey";
-    http.Response response = await http.get(Uri.parse(url));
+    http.Response response =
+        await http.get(Uri.parse(url), headers: await _headers());
     if (response.statusCode != 200) {
       return Failure(
           Exception("Error while loading species synonyms from Flora Codex"));


### PR DESCRIPTION
Hey Plant-it community! This PR adds a User-Agent header to the requests Plant-it sends to the Flora Codex API. Beyond being an industry best practice for API clients, it makes that traffic properly labeled and identifiable on our side, so we can tell it's coming from Plant-it.

## What's new?
All three Flora Codex calls (species search, species detail, synonyms) now send a `User-Agent` header of the form `plant-it/<version> (<platform>)`, e.g. `plant-it/1.0.1 (android)`.

- The app version comes from `package_info_plus` (`PackageInfo.fromPlatform()`), the same call already used on the info screen.
- The platform comes from `Platform.operatingSystem` (`android`/`ios`/`macos`/`linux`/`windows`/`fuchsia`).
- It's built once and memoized, resolved lazily on the first request rather than only in `_initialize()`. That way the `getDetails` path is covered too, since it doesn't go through `search()`/`_initialize()`.

While I was in there I also fixed a latent double slash in the request path: `version` was `"/v1/"`, which produced `.../v1//species/...`. It's now `"/v1"`, matching the single-slash paths in the API's own `self` links.

## Why is it important?
A User-Agent lets the backend see which client and version traffic comes from. That's useful for triaging support requests, understanding version adoption, and spotting misbehaving builds. It's also good HTTP hygiene. No personal data is sent: only the app name, version, and OS family.

## How to Use?
Nothing changes for users. The header is attached automatically on every Flora Codex request.

## Notes
- No web guard is needed: `dart:io` is already imported across `lib/` (including `database.dart`), so web isn't a build target here.
- Independent of the open key-refresh PR (#613). Different files, no conflict.
- `flutter analyze` and `flutter test` pass.
